### PR TITLE
Reissue last PR without the sb-simd files

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -97,6 +97,10 @@ jobs:
           ./sbcl --version
           sudo mv ./sbcl /usr/bin
           sbcl --version
+          curl -O https://beta.quicklisp.org/quicklisp.lisp
+          sbcl --noinform --load quicklisp.lisp --eval "(quicklisp-quickstart:install)" --eval "(ql-util:without-prompting (ql:add-to-init-file))" --eval "(exit)"
+          #git clone https://github.com/marcoheisig/sb-simd.git $HOME/quicklisp/local-projects/sb-simd
+          #sbcl --noinform --eval "(ql:quickload :sb-simd)" --eval "(exit)"
       - name: Install racket
         if: matrix.lang == 'racket'
         run: |

--- a/bench/algorithm/nbody/3.cl
+++ b/bench/algorithm/nbody/3.cl
@@ -1,0 +1,166 @@
+;;;   The Computer Language Benchmarks Game
+;;;   http://benchmarksgame.alioth.debian.org/
+;;;
+;;; contributed by Patrick Frankenberger
+;;; modified by Juho Snellman 2005-11-18
+;;;   * About 40% speedup on SBCL, 90% speedup on CMUCL
+;;;   * Represent a body as a DEFSTRUCT with (:TYPE VECTOR DOUBLE-FLOAT), a
+;;;     not as a structure that contains vectors
+;;;   * Inline APPLYFORCES
+;;;   * Replace (/ DT DISTANCE DISTANCE DISTANCE) with
+;;;     (/ DT (* DISTANCE DISTANCE DISTANCE)), as is done in the other
+;;;     implementations of this test.
+;;;   * Add a couple of declarations
+;;;   * Heavily rewritten for style (represent system as a list instead of
+;;;     an array to make the nested iterations over it less clumsy, use
+;;;     INCF/DECF where appropriate, break very long lines, etc)
+;;; modified by Marko Kocic 
+;;;   * add optimization declarations
+;;; modified by Bela Pecsek
+;;;   * code modification useing scaling method and use dt 1.0d0
+;;;   * calculate magnitude by (/ 1.0d0 (* dist_sq distance))
+;;;   * precompute mass * mag instead of dx,y,z * mag 
+;;; sbcl --load nbody3.lisp --no-userinit --eval "(setf *block-compile-default* t)" --eval "(save-lisp-and-die \"nbody3.core\" :executable t :purify t :toplevel (lambda () (main) (quit)))"
+
+(declaim (optimize (speed 3) (safety 0) (space 0) (debug 0)))
+(setf *block-compile-default* t)
+
+(defconstant +days-per-year+ 365.24d0)
+(defconstant +solar-mass+ (* 4d0 pi pi))
+
+(defstruct (body (:type (vector double-float))
+                 (:conc-name nil)
+                 (:constructor make-body (x y z vx vy vz mass)))
+  x y z vx vy vz mass)
+
+(deftype body () '(vector double-float 7))
+
+(defparameter *jupiter*
+  (make-body 4.84143144246472090d0
+             -1.16032004402742839d0
+             -1.03622044471123109d-1
+             (* 1.66007664274403694d-3 +days-per-year+)
+             (* 7.69901118419740425d-3 +days-per-year+)
+             (* -6.90460016972063023d-5  +days-per-year+)
+             (* 9.54791938424326609d-4 +solar-mass+)))
+
+(defparameter *saturn*
+  (make-body 8.34336671824457987d0
+             4.12479856412430479d0
+             -4.03523417114321381d-1
+             (* -2.76742510726862411d-3 +days-per-year+)
+             (* 4.99852801234917238d-3 +days-per-year+)
+             (* 2.30417297573763929d-5 +days-per-year+)
+             (* 2.85885980666130812d-4 +solar-mass+)))
+
+(defparameter *uranus*
+  (make-body 1.28943695621391310d1
+             -1.51111514016986312d1
+             -2.23307578892655734d-1
+             (* 2.96460137564761618d-03 +days-per-year+)
+             (* 2.37847173959480950d-03 +days-per-year+)
+             (* -2.96589568540237556d-05 +days-per-year+)
+             (* 4.36624404335156298d-05 +solar-mass+)))
+
+(defparameter *neptune*
+  (make-body 1.53796971148509165d+01
+             -2.59193146099879641d+01
+             1.79258772950371181d-01
+             (* 2.68067772490389322d-03 +days-per-year+)
+             (* 1.62824170038242295d-03 +days-per-year+)
+             (* -9.51592254519715870d-05 +days-per-year+)
+             (* 5.15138902046611451d-05 +solar-mass+)))
+
+(defparameter *sun*
+  (make-body 0d0 0d0 0d0 0d0 0d0 0d0 +solar-mass+))
+
+(declaim (inline applyforces))
+(defun applyforces (a b)
+  (let* ((dx (- (x a) (x b)))
+         (dy (- (y a) (y b)))
+         (dz (- (z a) (z b)))
+	 (posdelta_sq (+ (* dx dx) (* dy dy) (* dz dz)))
+	 (distance (sqrt posdelta_sq))
+	 (mag (/ (* posdelta_sq distance)))
+	 (massmag-b (* mag (mass b)))
+	 (massmag-a (* mag (mass a))))
+    (declare (body a b)(double-float dx dy dz)
+	     ((double-float 0d0) posdelta_sq distance
+	      mag massmag-a massmag-b))
+    (decf (vx a) (* dx massmag-b))
+    (decf (vy a) (* dy massmag-b))
+    (decf (vz a) (* dz massmag-b))
+    (incf (vx b) (* dx massmag-a))
+    (incf (vy b) (* dy massmag-a))
+    (incf (vz b) (* dz massmag-a))))
+
+(declaim (inline advance))
+(defun advance (system)
+  (loop for (a . rest) on system do
+    (dolist (b rest)
+          (applyforces a b)))
+  (dolist (a system)
+    (incf (x a) (vx a))
+    (incf (y a) (vy a))
+    (incf (z a) (vz a)))
+  nil)
+
+(declaim (inline energy))
+(defun energy (system)
+    (let ((e 0d0))
+    (declare (double-float e))
+      (loop for (a . rest) on system do
+          (incf e (* 0.5d0 (mass a)
+                     (+ (* (vx a) (vx a))
+                        (* (vy a) (vy a))
+                        (* (vz a) (vz a)))))
+          (dolist (b rest)
+            (let* ((dx (- (x a) (x b)))
+                   (dy (- (y a) (y b)))
+                   (dz (- (z a) (z b)))
+		   (dist (sqrt (+ (* dx dx) (* dy dy) (* dz dz)))))
+              (decf e (/ (* (mass a) (mass b)) dist)))))
+    e))
+
+(defun offset-momentum (system)
+  (let ((px 0d0)
+	(py 0d0)
+	(pz 0d0)
+	(sun (car system)))
+    (dolist (p system)
+      (incf px (* (vx p) (mass p)))
+      (incf py (* (vy p) (mass p)))
+      (incf pz (* (vz p) (mass p))))
+    (setf (vx sun) (/ (- px) +solar-mass+)
+          (vy sun) (/ (- py) +solar-mass+)
+          (vz sun) (/ (- pz) +solar-mass+))
+    nil))
+
+(defun body-scale (system scale)
+  (dolist (p system)
+    (declare (type body p)
+	     (type list system))
+    (setf (mass p) (* (mass p) (* scale scale))
+	  (vx p) (* (vx p) scale)
+	  (vy p) (* (vy p) scale)
+	  (vz p) (* (vz p) scale))))
+
+(defconstant +DT+ 0.01d0)
+(defconstant +RECIP_DT+ (/ 1d0 +DT+))
+
+(defun nbody (n)
+  (declare (fixnum n))
+  (let ((system (list *sun* *jupiter* *saturn* *uranus* *neptune*)))
+    (offset-momentum system)
+    (format t "~,9F~%" (energy system))
+    (body-scale system +DT+)
+    (dotimes (i n)
+      (advance system))
+    (body-scale system +RECIP_DT+)
+    (format t "~,9F~%" (energy system))))
+
+(defun main ()
+  (let ((n (parse-integer (or (car (last #+sbcl sb-ext:*posix-argv*
+                                         #+cmu  extensions:*command-line-strings*
+					 #+gcl  si::*command-args*)) "1"))))
+    (nbody n)))

--- a/bench/algorithm/spectral-norm/1.cl
+++ b/bench/algorithm/spectral-norm/1.cl
@@ -1,0 +1,105 @@
+;;    The Computer Language Benchmarks Game
+;;    https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+;;
+;;    Adapted from the C (gcc) code by Sebastien Loisel
+;;
+;;    Contributed by Christopher Neufeld
+;;    Modified by Juho Snellman 2005-10-26
+;;      * Use SIMPLE-ARRAY instead of ARRAY in declarations
+;;      * Use TRUNCATE instead of / for fixnum division
+;;      * Rearrange EVAL-A to make it more readable and a bit faster
+;;    Modified by Andy Hefner 2008-09-18
+;;      * Eliminate array consing
+;;      * Clean up type declarations in eval-A
+;;      * Distribute work across multiple cores on SBCL
+;;    Modified by Witali Kusnezow 2008-12-02
+;;      * use right shift instead of truncate for division in eval-A
+;;      * redefine eval-A as a macro
+;;    Optimize declaration and get-thread-count added by Bela Pecsek
+
+
+;; This is our most expensive function.  Optimized with the knowledge
+;; that 'n' will never be "huge".  This will break if 'n' exceeds
+;; approximately half of the square root of the largest fixnum
+;; supported by the implementation.  On 32-bit sbcl,
+;; 'most-positive-fixnum' is 536870911, and we can support values of
+;; 'n' above 11000.
+(declaim (optimize (speed 3) (safety 0) (space 0) (debug 0)))
+
+(defmacro eval-A (i j)
+  `(let* ((n (+ ,i ,j))
+          (n+1 (1+ n)))
+     (declare (type (integer 0 22000) n n+1))
+     (/ (float (+ (ash (* n n+1) -1) ,i 1) 0d0))))
+
+(defun eval-At-times-u (u n Au start end)
+  (declare (type fixnum n start end)
+           (type (simple-array double-float) u Au))
+  (loop for i from start below end do
+        (setf (aref Au i)
+              (loop for j below n
+                    summing (* (aref u j) (eval-A j i))
+                    of-type double-float))))
+
+(defun eval-A-times-u (u n Au start end)
+  (declare (type fixnum n start end)
+           (type (simple-array double-float) u Au))
+  (loop for i from start below end do
+        (setf (aref Au i)
+              (loop for j below n
+                    summing (* (aref u j) (eval-A i j))
+                    of-type double-float))))
+
+#+sb-thread
+(defun get-thread-count ()
+  (progn (define-alien-routine sysconf long (name int))
+         (sysconf 84)))
+
+#+sb-thread
+(defun execute-parallel (start end function)
+  (declare (optimize (speed 0)))
+  (let* ((num-threads (get-thread-count)))
+    (loop with step = (truncate (- end start) num-threads)
+          for index from start below end by step
+          collecting (let ((start index)
+                           (end (min end (+ index step))))
+                       (sb-thread:make-thread
+                        (lambda () (funcall function start end))))
+          into threads
+          finally (mapcar #'sb-thread:join-thread threads))))
+
+#-sb-thread
+(defun execute-parallel (start end function )
+  (funcall function start end))
+
+(defun eval-AtA-times-u (u AtAu v n start end)
+  (execute-parallel start end
+    (lambda (start end)
+      (eval-A-times-u u n v start end)))
+  (execute-parallel start end
+    (lambda (start end)
+      (eval-At-times-u v n AtAu start end))))
+
+(defun main (&optional n-supplied)
+  (let ((n (or n-supplied
+               (parse-integer (or (car (last #+sbcl sb-ext:*posix-argv*
+                                             #+clisp ext:*args*
+                                             #+cmu extensions:*command-line-strings*
+                                             #+gcl  si::*command-args*))
+                                  "3000")))))
+    (declare (type fixnum n))
+    (or (typep (* (- (* 2 n) 1) (- (* 2 n) 2)) 'fixnum)
+        (error "The supplied value of 'n' breaks the optimizations in EVAL-A"))
+    (let ((u (make-array n :element-type 'double-float :initial-element 1.0d0))
+          (v (make-array n :element-type 'double-float))
+          (tmp (make-array n :element-type 'double-float)))
+      (declare (type (simple-array double-float) U V))
+      (dotimes (i 10)
+        (eval-AtA-times-u u v tmp n 0 n)
+        (eval-AtA-times-u v u tmp n 0 n))
+      (let ((vBv 0.0d0)
+            (vv 0.0d0))
+        (dotimes (i n)
+          (incf vBv (* (aref u i) (aref v i)))
+          (incf vv (* (aref v i) (aref v i))))
+        (format t "~11,9F~%" (sqrt (the (double-float 0d0) (/ vBv vv))))))))

--- a/bench/algorithm/spectral-norm/7.cpp
+++ b/bench/algorithm/spectral-norm/7.cpp
@@ -1,0 +1,123 @@
+// The Computer Language Benchmarks Game
+// https://salsa.debian.org/benchmarksgame-team/benchmarksgame/
+//
+// Original C contributed by Sebastien Loisel
+// Conversion to C++ by Jon Harrop
+// OpenMP parallelize by The Anh Tran
+// Add SSE by The Anh Tran
+// Additional SSE optimization by Krzysztof Jakubowski
+// Converted to AVX by Tomas Wain
+
+// g++ -pipe -O3  -fomit-frame-pointer -march=native -fopenmp -mavx2 \
+// spectralnorm.cpp-7.c++ -o spectralnorm.gpp-7.c++.o && \
+// g++ spectralnorm.gpp-7.c++.o -o spectralnorm.gpp-7.gpp_run -fopenmp
+
+#include <cmath>
+#include <cstdlib>
+#include <cstdio>
+#include <sys/sysinfo.h>
+#include <sched.h>
+#include <omp.h>
+#include <immintrin.h>
+
+template <bool modei> int Index(int i, int j) {
+    return (((i + j) * (i + j + 1)) >> 1) + (modei? i : j) + 1;
+}
+
+template <bool modei>
+void EvalPart(double *__restrict__ src, double *__restrict__ dst,
+                int begin, int end, int length) {
+    int i = begin;
+
+    for(; i + 1 < end; i += 4) {
+        __m256d sum = _mm256_set_pd(src[0] / double(Index<modei>(i + 3, 0)),
+				    src[0] / double(Index<modei>(i + 2, 0)),
+				    src[0] / double(Index<modei>(i + 1, 0)),
+				    src[0] / double(Index<modei>(i + 0, 0)));
+    
+	__m256d ti = modei? _mm256_set_pd(i + 3, i + 2, i + 1, i + 0) :
+	                    _mm256_set_pd(i + 4, i + 3, i + 2, i + 1);	
+	
+	__m256d last = _mm256_set_pd(Index<modei>(i + 3, 0),
+				     Index<modei>(i + 2, 0),
+				     Index<modei>(i + 1, 0),
+				     Index<modei>(i + 0, 0));
+
+        for(int j = 1; j < length; j++) {
+	  __m256d idx = last + ti + _mm256_set1_pd(j);
+	  last = idx;
+	  sum += _mm256_set1_pd(src[j]) / idx;
+        }
+
+        _mm256_storeu_pd(dst + i, sum);
+    }
+}
+
+void EvalATimesU(double *src, double *dst, int begin, int end, int N) {
+    EvalPart<1>(src, dst, begin, end, N);
+}
+
+void EvalAtTimesU(double *src, double *dst, int begin, int end, int N) {
+    EvalPart<0>(src, dst, begin, end, N);
+}
+
+void EvalAtATimesU(double *src, double *dst, double *tmp,
+                   int begin, int end, int N) {
+    EvalATimesU (src, tmp, begin, end, N);
+    #pragma omp barrier
+    EvalAtTimesU(tmp, dst, begin, end, N);
+    #pragma omp barrier
+}
+
+int GetThreadCount() {
+  return get_nprocs();
+}
+
+double spectral_game(int N) {
+    __attribute__((aligned(32))) double u[N+3], v[N+3], tmp[N+3];
+
+    double vBv = 0.0;
+    double vv = 0.0;
+
+#pragma omp parallel default(shared) num_threads(GetThreadCount())
+    {
+        // this block will be executed by NUM_THREADS
+        // variable declared in this block is private for each thread
+        int threadid = omp_get_thread_num();
+        int threadcount = omp_get_num_threads();
+        int chunk = N / threadcount;
+
+        // calculate each thread's working range [r1 .. r2) => static schedule
+        int begin = threadid * chunk;
+        int end = (threadid < (threadcount -1)) ? (begin + chunk) : N;
+
+        for(int i = begin; i < end; i++)
+            u[i] = 1.0;
+        #pragma omp barrier
+
+        for (int ite = 0; ite < 10; ++ite) {
+            EvalAtATimesU(u, v, tmp, begin, end, N);
+            EvalAtATimesU(v, u, tmp, begin, end, N);
+        }
+
+        double sumvb = 0.0, sumvv = 0.0;
+        for (int i = begin; i < end; i++) {
+            sumvv += v[i] * v[i];
+            sumvb += u[i] * v[i];
+        }
+
+        #pragma omp critical
+        {
+            vBv += sumvb;
+            vv += sumvv;
+        }
+    }
+    
+    return sqrt(vBv / vv);
+}
+
+int main(int argc, char *argv[]) {
+    int N = ((argc >= 2) ? atoi(argv[1]) : 2000);
+    printf("%.9f\n", spectral_game(N));
+    return 0;
+}

--- a/bench/bench_lisp.yaml
+++ b/bench/bench_lisp.yaml
@@ -20,20 +20,20 @@ environments:
     compiler: sbcl
     version: latest
     include: lisp
-    build: sbcl --non-interactive --no-userinit --load compile.cl
+    build: sbcl --dynamic-space-size 8Gb --noinform --non-interactive --no-userinit --load compile.cl
     after_build:
       - cp app.fasl out
       - cp run.cl out
     out_dir: out
     compiler_version_command: sbcl --version
     runtime_version_parameter: --version
-    run_cmd: sbcl --non-interactive --no-userinit --load run.cl
+    run_cmd: sbcl --dynamic-space-size 8Gb --noinform --non-interactive --no-userinit --load run.cl
     runtime_included: false
   - os: linux
     compiler: sbcl/exe
     version: latest
     include: lisp
-    build: sbcl --non-interactive --no-userinit --load bundle.cl
+    build: sbcl --dynamic-space-size 8Gb --noinform --disable-debugger --non-interactive --no-userinit --load bundle.cl
     after_build:
       - cp app out
     out_dir: out

--- a/bench/bench_lisp.yaml
+++ b/bench/bench_lisp.yaml
@@ -6,6 +6,10 @@ problems:
   - name: nbody
     source:
       - 2.cl
+      - 3.cl
+  - name: spectral-norm
+    source:
+      - 1.cl
 compiler_version_command:
 compiler_version_regex:
 runtime_version_parameter:

--- a/bench/include/lisp/bundle.cl
+++ b/bench/include/lisp/bundle.cl
@@ -8,5 +8,5 @@
         :purify t
         ;; :compression t
         ;; this is the main function:
-        :toplevel #'mainc
+        :toplevel #'main
         :executable t))

--- a/bench/include/lisp/bundle.cl
+++ b/bench/include/lisp/bundle.cl
@@ -1,13 +1,12 @@
 (declaim (optimize (speed 3)(safety 0)(space 0)(debug 0)))
 
 (load (compile-file "app.cl"))
-(sb-ext:save-lisp-and-die 
-  "app"
-  ;; http://www.sbcl.org/manual/#Function-sb_002dext-save_002dlisp_002dand_002ddie
-  ;; :purify t
-  ;; :compression t
-  ;; this is the main function:
-  :toplevel (lambda () 
-              (main)                                      
-              0)
-  :executable t)
+(progn (sb-ext:disable-debugger)
+       (sb-ext:save-lisp-and-die 
+        "app"
+        ;; http://www.sbcl.org/manual/#Function-sb_002dext-save_002dlisp_002dand_002ddie
+        :purify t
+        ;; :compression t
+        ;; this is the main function:
+        :toplevel #'mainc
+        :executable t))


### PR DESCRIPTION
Quicklisp installation added
sb-simd added but commented out
A few non simd CL files added
A new spectral-norm cpp file added
dinamic-space-size increased to 8Gb and -noinform added
--disable-debuger added for save-lisp-and-die
bundle.cl improved (disable-debuger) and :purify t added, :toplevel changed to #'main for clarity