### PR TITLE
spectral-norm 5.cl added, code cleanup

### DIFF
--- a/bench/algorithm/spectral-norm/1.cl
+++ b/bench/algorithm/spectral-norm/1.cl
@@ -21,38 +21,38 @@
 ;;      * double-float values are always positive
 ;;      * threading slightly modified - 2021-09-19
 (declaim (optimize (speed 3) (safety 0) (space 0) (debug 0)))
-(setf *block-compile-default* t)
 
-(deftype uint31 (&optional (bits 31)) `(unsigned-byte ,bits))
-(deftype d+ () '(double-float 0d0))
+(deftype uint31   () '(unsigned-byte 31))
+(deftype d+       () '(double-float 0d0))
 (deftype array-d+ () '(simple-array d+ (*)))
 
-(defmacro eval-A (i j)
-  `(let* ((i+1   (1+ ,i))
-          (i+j   (+ ,i ,j))
-          (i+j+1 (+ i+1 ,j)))
-     (declare (type uint31 i+1 i+j i+j+1))
-     (/ (float (+ (ash (* i+j i+j+1) -1) i+1) 0d0))))
+(declaim (ftype (function (uint31 uint31) d+) eval-A)
+         (inline eval-A))
+(defun eval-A (i j)
+  (let* ((i+1   (1+ i))
+         (i+j   (+ i j))
+         (i+j+1 (+ i+1 j)))
+    (declare (type uint31 i+1 i+j i+j+1))
+    (/ (float (+ (ash (* i+j i+j+1) -1) i+1) 0d0))))
 
 (declaim (ftype (function (array-d+ uint31 array-d+ uint31 uint31) null)
                 eval-At-times-u eval-A-times-u))
 (defun eval-At-times-u (u n Au start end)
   (loop for i from start below end do
-    (setf (aref Au i)
-          (loop for j below n
-                summing (* (aref u j) (eval-A j i)) of-type d+))))
+    (setf (aref Au i) (loop for j below n
+                            summing (* (aref u j) (eval-A j i)) of-type d+))))
 
 (defun eval-A-times-u (u n Au start end)
   (loop for i from start below end do
-    (setf (aref Au i)
-          (loop for j below n
-                summing (* (aref u j) (eval-A i j)) of-type d+))))
+    (setf (aref Au i) (loop for j below n
+                            summing (* (aref u j) (eval-A i j)) of-type d+))))
 
 #+sb-thread
 (defun get-thread-count ()
   (progn (define-alien-routine sysconf long (name int))
          (sysconf 84)))
 
+(declaim (ftype (function (uint31 uint31 function) null) execute-parallel))
 #+sb-thread
 (defun execute-parallel (start end function)
   (declare (optimize (speed 0)))
@@ -77,10 +77,10 @@
                     (lambda (start end)
                       (eval-At-times-u v n AtAu start end))))
 
+(declaim (ftype (function (&optional uint31) null) main))
 (defun main (&optional n-supplied)
-  (let ((n (or n-supplied
-               (parse-integer (or (car (last sb-ext:*posix-argv*)) "3000")))))
-    (declare (type uint31 n))
+  (let ((n (or n-supplied (parse-integer (or (car (last sb-ext:*posix-argv*))
+                                  "5000")))))
     (or (typep (* (- (* 2 n) 1) (- (* 2 n) 2)) 'fixnum)
         (error "The supplied value of 'n' breaks the optimizations in EVAL-A"))
     (let ((u   (make-array n :element-type 'd+ :initial-element 1d0))
@@ -91,9 +91,9 @@
         (eval-AtA-times-u u v tmp n 0 n)
         (eval-AtA-times-u v u tmp n 0 n))
       (let ((vBv 0d0)
-            (vv 0.0d0))
+            (vv  0d0))
         (loop for i below n do
-          (let ((aref-v (aref v i)))
-            (incf vBv (* (aref u i) aref-v))
-            (incf vv  (* aref-v aref-v))))
+          (let ((aref-vi (aref v i)))
+            (incf vBv (* (aref u i) aref-vi))
+            (incf vv  (* aref-vi aref-vi))))
         (format t "~11,9F~%" (sqrt (the d+ (/ vBv vv))))))))

--- a/bench/algorithm/spectral-norm/2.cl
+++ b/bench/algorithm/spectral-norm/2.cl
@@ -25,7 +25,7 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (ql:quickload :sb-simd)
-  (use-package :sb-simd-avx))
+  (use-package :sb-simd-avx2))
 
 (declaim (ftype (function (f64.4 f64.4) f64.4) eval-A)
          (inline eval-A))
@@ -80,8 +80,7 @@
                   collecting (let ((start i)
                                    (end (min end (+ i step))))
                                (sb-thread:make-thread
-			        (lambda () (funcall function start end))))
-                  of-type thread))))
+			        (lambda () (funcall function start end))))))))
 
 #-sb-thread
 (defun execute-parallel (start end function)

--- a/bench/algorithm/spectral-norm/4.cl
+++ b/bench/algorithm/spectral-norm/4.cl
@@ -25,7 +25,7 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (ql:quickload :sb-simd)
-  (use-package :sb-simd-avx))
+  (use-package :sb-simd-avx2))
 
 (declaim (ftype (function (f64.2 f64.2) f64.2) eval-A)
          (inline eval-A))
@@ -40,18 +40,17 @@
 (defun eval-A-times-u (src dst begin end length)
   (loop for i of-type u32 from begin below end by 4
         with src-0 of-type f64 = (aref src 0)
-	do (let* ((ti0   (make-f64.2 (+ i 0) (+ i 1)))
-		  (ti1   (make-f64.2 (+ i 2) (+ i 3)))
+	do (let* ((ti0   (f64.2+ i (make-f64.2 0 1)))
+		  (ti1   (f64.2+ i (make-f64.2 2 3)))
 		  (eA0   (eval-A ti0 (f64.2 0)))
 		  (eA1   (eval-A ti1 (f64.2 0)))
 		  (sum0  (f64.2/ src-0 eA0))
 		  (sum1  (f64.2/ src-0 eA1)))
 	     (loop for j of-type u32 from 1 below length
-		   do (let* ((src-j (aref src j))
-			     (idx0 (f64.2+ eA0 ti0 j))
-			     (idx1 (f64.2+ eA1 ti1 j)))
-			(setf eA0 idx0
-                              eA1 idx1)
+                   for src-j of-type f64 = (aref src j)
+		   do (let ((idx0 (f64.2+ eA0 ti0 j))
+			    (idx1 (f64.2+ eA1 ti1 j)))
+			(setf eA0 idx0 eA1 idx1)
 			(f64.2-incf sum0 (f64.2/ src-j idx0))
 			(f64.2-incf sum1 (f64.2/ src-j idx1))))
              (setf (f64.2-aref dst i) sum0)
@@ -60,18 +59,17 @@
 (defun eval-At-times-u (src dst begin end length)
   (loop for i of-type u32 from begin below end by 4
         with src-0 of-type f64 = (aref src 0)
-	do (let* ((ti0   (make-f64.2 (+ i 1) (+ i 2)))
-		  (ti1   (make-f64.2 (+ i 3) (+ i 4)))
+	do (let* ((ti0   (f64.2+ i (make-f64.2 1 2)))
+		  (ti1   (f64.2+ i (make-f64.2 3 4)))
                   (eAt0  (eval-A (f64.2 0) (f64.2- ti0 1)))
 		  (eAt1  (eval-A (f64.2 0) (f64.2- ti1 1)))
                   (sum0  (f64.2/ src-0 eAt0))
 		  (sum1  (f64.2/ src-0 eAt1)))
 	     (loop for j of-type u32 from 1 below length
-                   do (let* ((src-j (aref src j))
-			     (idx0  (f64.2+ eAt0 ti0 j))
-			     (idx1  (f64.2+ eAt1 ti1 j)))
-			(setf eAt0 idx0
-                              eAt1 idx1)
+                   for src-j of-type f64 = (aref src j)
+                   do (let ((idx0  (f64.2+ eAt0 ti0 j))
+			    (idx1  (f64.2+ eAt1 ti1 j)))
+			(setf eAt0 idx0 eAt1 idx1)
 			(f64.2-incf sum0 (f64.2/ src-j idx0))
 			(f64.2-incf sum1 (f64.2/ src-j idx1))))
 	     (setf (f64.2-aref dst i) sum0)
@@ -89,12 +87,12 @@
   (declare (optimize (speed 0)))
   (let* ((n (truncate (- end start) (get-thread-count)))
          (step (- n (mod n 2))))
-    (loop for i from start below end by step
-          collecting (let ((start i)
-                           (end (min end (+ i step))))
-                       (sb-thread:make-thread
-			(lambda () (funcall function start end))))
-            into threads          finally (mapcar #'sb-thread:join-thread threads))))
+    (mapcar #'sb-thread:join-thread
+            (loop for i from start below end by step
+                  collecting (let ((start i)
+                                   (end (min end (+ i step))))
+                               (sb-thread:make-thread
+			        (lambda () (funcall function start end))))))))
 
 #-sb-thread
 (defun execute-parallel (start end function)

--- a/bench/algorithm/spectral-norm/5.cl
+++ b/bench/algorithm/spectral-norm/5.cl
@@ -51,11 +51,10 @@
                     (sum0 (f64.4/ src-0 eA0))
 		    (sum1 (f64.4/ src-0 eA1)))
 	       (loop for j from 1 below length
-		     do (let* ((src-j  (aref src j))
-			       (idx0  (f64.4+ eA0 ti0 j))
-			       (idx1  (f64.4+ eA1 ti1 j)))
-			  (setf eA0 idx0
-                                eA1 idx1)
+		     do (let ((src-j (aref src j))
+                              (idx0  (f64.4+ eA0 ti0 j))
+			      (idx1  (f64.4+ eA1 ti1 j)))
+			  (setf eA0 idx0 eA1 idx1)
 			  (setf sum0 (f64.4+ sum0 (f64.4/ src-j idx0)))
 			  (setf sum1 (f64.4+ sum1 (f64.4/ src-j idx1)))))
                (setf (f64.4-aref dst i) sum0)
@@ -71,11 +70,10 @@
                      (sum0  (f64.4/ src-0 eAt0))
 		     (sum1  (f64.4/ src-0 eAt1)))
 	        (loop for j from 1 below length
-		      do (let* ((src-j  (aref src j))
-                                (idx0  (f64.4+ eAt0 ti0 j))
-			        (idx1  (f64.4+ eAt1 ti1 j)))
-			   (setf eAt0 idx0
-                                 eAt1 idx1)
+		      do (let ((src-j (aref src j))
+                               (idx0  (f64.4+ eAt0 ti0 j))
+			       (idx1  (f64.4+ eAt1 ti1 j)))
+			   (setf eAt0 idx0 eAt1 idx1)
 			   (setf sum0 (f64.4+ sum0 (f64.4/ src-j idx0)))
 			   (setf sum1 (f64.4+ sum1 (f64.4/ src-j idx1)))))
                 (setf (f64.4-aref dst i) sum0)
@@ -97,8 +95,7 @@
                   collecting (let ((start i)
                                    (end (min end (+ i step))))
                                (sb-thread:make-thread
-			        (lambda () (funcall function start end))))
-                  of-type thread))))
+			        (lambda () (funcall function start end))))))))
 
 #-sb-thread
 (defun execute-parallel (start end function)
@@ -113,9 +110,9 @@
 
 (declaim (ftype (function (u32) f64) spectralnorm))
 (defun spectralnorm (n)
-  (let ((u   (make-array (+ n 3) :element-type 'f64 :initial-element 1d0))
-        (v   (make-array (+ n 3) :element-type 'f64))
-        (tmp (make-array (+ n 3) :element-type 'f64)))
+  (let ((u   (make-array (+ n 7) :element-type 'f64 :initial-element 1d0))
+        (v   (make-array (+ n 7) :element-type 'f64))
+        (tmp (make-array (+ n 7) :element-type 'f64)))
     (declare (type f64vec u v tmp))
     (loop repeat 10 do
       (eval-AtA-times-u u v tmp 0 n n)

--- a/bench/algorithm/spectral-norm/6.cl
+++ b/bench/algorithm/spectral-norm/6.cl
@@ -16,7 +16,7 @@
 ;;      * use right shift instead of truncate for division in eval-A
 ;;      * redefine eval-A as a macro
 ;;    Modified by Bela Pecsek
-;;      * Using SSE calculations and SSE2 only instruction sets
+;;      * Using SSE registers but AVX2 VEX vector instruction sets
 ;;      * Improvement in type declarations
 ;;      * Redefine eval-A as inlined function using sse simd
 ;;      * Changed code to be compatible with sb-simd
@@ -24,7 +24,7 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (ql:quickload :sb-simd)
-  (use-package :sb-simd-sse2))
+  (use-package :sb-simd-avx2))
 
 (declaim (ftype (function (f64.2 f64.2) f64.2) eval-A)
          (inline eval-A))

--- a/bench/bench_lisp.yaml
+++ b/bench/bench_lisp.yaml
@@ -26,7 +26,7 @@ problems:
       - 2.cl
       - 3.cl
       - 4.cl
-      #- 5.cl
+      - 5.cl
   - name: nsieve
     source:
       - 1.cl

--- a/bench/bench_lisp.yaml
+++ b/bench/bench_lisp.yaml
@@ -27,6 +27,7 @@ problems:
       - 3.cl
       - 4.cl
       - 5.cl
+      - 6.cl
   - name: nsieve
     source:
       - 1.cl


### PR DESCRIPTION
* 5.cl spectral-norm code fixed and added
* 3.cl spectral-norm code changed to use sse operations only to make it directly comparable to other languages using sse only 
* All other CL spectral-norm codes are cleaned up