### PR TITLE
Latest sb-simd fails to build under sbcl-2.1.10

### DIFF
--- a/.github/lisp.sh
+++ b/.github/lisp.sh
@@ -12,5 +12,7 @@ curl -O https://beta.quicklisp.org/quicklisp.lisp
 sbcl --noinform --load quicklisp.lisp --eval "(quicklisp-quickstart:install)" --eval "(ql-util:without-prompting (ql:add-to-init-file))" --eval "(exit)"
 git clone https://github.com/marcoheisig/sb-simd $HOME/quicklisp/local-projects/sb-simd
 cd $HOME/quicklisp/local-projects/sb-simd
+git checkout a784fe831792764e88368656fa7fd643e33b712b
+cd $HOME
 sbcl --noinform --eval "(ql:quickload :sb-simd)" --eval "(exit)"
 sbcl --version


### PR DESCRIPTION
Since development of sb-simd goes hand in hand with sbcl at the moment the latest head of sb-simd builds only under the development head of sbcl.

Could you please accept this PR and rerun the GH action?

Would it be possible to set up a nightly sbcl, like for other languages to enable us to test regressions as well?