### PR TITLE
tlsEmulation off for nim builds

### DIFF
--- a/bench/bench_nim.yaml
+++ b/bench/bench_nim.yaml
@@ -49,7 +49,7 @@ environments:
     include: nim
     include_sub_dir:
     before_build:
-    build: nimble build app -y --cc:clang --mm:orc -d:danger --panics:on -d:nimCoroutines --threads:on --tlsEmulation:off --verbose
+    build: nimble build app -y --mm:orc -d:danger --panics:on -d:nimCoroutines --threads:on --tlsEmulation:off --verbose
     after_build:
       - cp app out
     out_dir: out

--- a/bench/bench_nim.yaml
+++ b/bench/bench_nim.yaml
@@ -49,7 +49,7 @@ environments:
     include: nim
     include_sub_dir:
     before_build:
-    build: nimble build app -y -x:off -a:off --mm:orc -d:release -d:danger -d:nimCoroutines --threads:on --tlsEmulation:off --opt:speed --verbose
+    build: nimble build app -y -x:off -a:off --mm:orc -d:release -d:danger --panics:on -d:nimCoroutines --threads:on --tlsEmulation:off --opt:speed --verbose
     after_build:
       - cp app out
     out_dir: out

--- a/bench/bench_nim.yaml
+++ b/bench/bench_nim.yaml
@@ -49,7 +49,7 @@ environments:
     include: nim
     include_sub_dir:
     before_build:
-    build: nimble build app -y -x:off -a:off --mm:orc -d:release -d:danger -d:nimCoroutines --threads:on --opt:speed --verbose
+    build: nimble build app -y -x:off -a:off --mm:orc -d:release -d:danger -d:nimCoroutines --threads:on --tlsEmulation:off --opt:speed --verbose
     after_build:
       - cp app out
     out_dir: out

--- a/bench/bench_nim.yaml
+++ b/bench/bench_nim.yaml
@@ -49,7 +49,7 @@ environments:
     include: nim
     include_sub_dir:
     before_build:
-    build: nimble build app -y -x:off -a:off --mm:orc -d:release -d:danger --panics:on -d:nimCoroutines --threads:on --tlsEmulation:off --opt:speed --verbose
+    build: nimble build app -y -x:off -a:off --cc:clang --mm:orc -d:release -d:danger --panics:on -d:nimCoroutines --threads:on --tlsEmulation:off --opt:speed --verbose
     after_build:
       - cp app out
     out_dir: out

--- a/bench/bench_nim.yaml
+++ b/bench/bench_nim.yaml
@@ -49,7 +49,7 @@ environments:
     include: nim
     include_sub_dir:
     before_build:
-    build: nimble build app -y -x:off -a:off --cc:clang --mm:orc -d:release -d:danger --panics:on -d:nimCoroutines --threads:on --tlsEmulation:off --opt:speed --verbose
+    build: nimble build app -y --cc:clang --mm:orc -d:danger --panics:on -d:nimCoroutines --threads:on --tlsEmulation:off --verbose
     after_build:
       - cp app out
     out_dir: out


### PR DESCRIPTION
There is a know performance regression caused by the tlsEmulation switch when threads:on, turn it off.