### PR TITLE
Use --mcpu=broadwell option for Crystal too

### DIFF
--- a/bench/bench_crystal.yaml
+++ b/bench/bench_crystal.yaml
@@ -54,6 +54,6 @@ environments:
     include_sub_dir: src
     before_build:
       - shards install
-    build: shards build --release
+    build: shards build --release --mcpu=broadwell
     out_dir: bin
     run_cmd: app


### PR DESCRIPTION
Almost every other compiler is optimizing for broadwell. Crystal compiler can do it too:

```
$ crystal build --help
Usage: crystal build [options] [programfile] [--] [arguments]

Options:
    --cross-compile                  cross-compile
    -d, --debug                      Add full symbolic debug info
    --no-debug                       Skip any symbolic debug info
    -D FLAG, --define FLAG           Define a compile-time flag
    --emit [asm|obj|llvm-bc|llvm-ir] Comma separated list of types of output for the compiler to emit
    -f text|json, --format text|json Output format text (default) or json
    --error-trace                    Show full error trace
    -h, --help                       Show this message
    --ll                             Dump ll to Crystal's cache directory
    --link-flags FLAGS               Additional flags to pass to the linker
    --mcpu CPU                       Target specific cpu type
[...]
```

```
$ shards build --help
shards [<options>...] [<command>]

Commands:
    build [<targets>] [<build_options>]  - Build the specified <targets> in `bin` path, all build_options are delegated to `crystal build`.
[...]
```

One tricky thing is that it's necessary to use the `--mcpu=broadwell` format instead of `--mcpu broadwell`. The shards tool can only handle the former and gets confused by the latter.