### PR TITLE
Change `class Planet` to `struct Planet` for an about 4x speedup

### DIFF
--- a/bench/algorithm/nbody/1.cr
+++ b/bench/algorithm/nbody/1.cr
@@ -9,7 +9,7 @@
 SOLAR_MASS    = 4_f64 * Math::PI**2
 DAYS_PER_YEAR = 365.24_f64
 
-class Planet
+struct Planet
   property x
   property y
   property z


### PR DESCRIPTION
In Crystal, there can be a performance overhead in the heap-allocated class type vs the stack-allocated struct type. Simply changing `class Planet` to `struct Planet` produces much faster code for me.