### PR TITLE
Use mimalloc in rust binarytree

### DIFF
--- a/bench/algorithm/binarytrees/6.rs
+++ b/bench/algorithm/binarytrees/6.rs
@@ -1,0 +1,73 @@
+use std::cmp::max;
+
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+struct TreeNode {
+    l: Option<Box<TreeNode>>,
+    r: Option<Box<TreeNode>>,
+}
+
+impl TreeNode {
+    fn check(self) -> i32 {
+        let mut ret = 1;
+        if let Some(l) = self.l {
+            ret += l.check();
+        }
+        if let Some(r) = self.r {
+            ret += r.check();
+        }
+        ret
+    }
+
+    fn create(depth: i32) -> Box<Self> {
+        let tree = if depth > 0 {
+            TreeNode {
+                l: Some(Self::create(depth - 1)),
+                r: Some(Self::create(depth - 1)),
+            }
+        } else {
+            TreeNode { l: None, r: None }
+        };
+        Box::new(tree)
+    }
+}
+
+const MIN_DEPTH: i32 = 4;
+
+fn main() {
+    let n = std::env::args()
+        .nth(1)
+        .and_then(|n| n.parse().ok())
+        .unwrap_or(10);
+    let max_depth = max(MIN_DEPTH + 2, n);
+
+    {
+        let stretch_depth = max_depth + 1;
+        let stretch_tree = TreeNode::create(stretch_depth);
+
+        println!(
+            "stretch tree of depth {}\t check: {}",
+            stretch_depth,
+            stretch_tree.check()
+        );
+    }
+
+    let long_lived_tree = TreeNode::create(max_depth);
+
+    for d in (MIN_DEPTH..=max_depth).step_by(2) {
+        let iterations = 1 << ((max_depth - d + MIN_DEPTH) as u32);
+        let mut chk = 0;
+        for _ in 0..iterations {
+            let a = TreeNode::create(d);
+            chk += a.check();
+        }
+        println!("{}\t trees of depth {}\t check: {}", iterations, d, chk)
+    }
+
+    println!(
+        "long lived tree of depth {}\t check: {}",
+        max_depth,
+        long_lived_tree.check()
+    );
+}

--- a/bench/bench_rust.yaml
+++ b/bench/bench_rust.yaml
@@ -8,6 +8,7 @@ problems:
       - 3.rs
       - 4.rs
       - 5.rs
+      - 6.rs
   - name: merkletrees
     source:
       - 1.rs

--- a/bench/include/rust/Cargo.toml
+++ b/bench/include/rust/Cargo.toml
@@ -35,6 +35,7 @@ k256 = "0"
 lasso = "0"
 lazy_static = "1"
 md5 = "0"
+mimalloc = { version = "0", default-features = false }
 num-bigint = "0"
 num-traits = "0"
 num_cpus = "1"


### PR DESCRIPTION
I could not find a good general purpose allocator written in pure rust.
But mimalloc, which is written in c, is really easy to use.
It requires just two line to enable globally.

The `check` function also takes `self` by value, for another small improvement.
This helps because the deallocation can already be done inside `check`.

@hanabi1224 what do you think?