### PR TITLE
Optimize Mandelbrot/1.java 

### DIFF
--- a/bench/algorithm/mandelbrot/1.java
+++ b/bench/algorithm/mandelbrot/1.java
@@ -3,102 +3,108 @@ import java.security.*;
 import java.util.stream.*;
 
 public final class app {
-    public static void main(String[] args) throws Exception {
-        int N = 100;
-        if (args.length >= 1) {
-            N = Integer.parseInt(args[0]);
-        }
+	public static void main(String[] args) throws Exception {
+		int N = 100;
+		if (args.length >= 1) {
+			N = Integer.parseInt(args[0]);
+		}
 
-        N = (N + 7) / 8 * 8;
-        int chunkSize = N / 8;
-        double inv = 2.0 / N;
+		N = (N + 7) / 8 * 8;
+		int chunkSize = N / 8;
+		double inv = 2.0 / N;
 
-        var xloc = new double[chunkSize][8];
-        for (int i = 0; i < N; i++) {
-            xloc[i / 8][i % 8] = inv * i - 1.5;
-        }
+		var xloc = new double[chunkSize][8];
+		for (int i = 0; i < N; i++) {
+			xloc[i / 8][i % 8] = inv * i - 1.5;
+		}
 
-        byte[] data = new byte[N * chunkSize];
-        IntStream.range(0, N)
-                .forEach(
-                        y -> {
-                            var ci = y * inv - 1.0;
-                            IntStream.range(0, chunkSize).forEach(x -> {
-                                data[y * chunkSize + x] = mbrot8(xloc[x], ci);
-                            });
-                        });
-        System.out.println("P4\n" + N + " " + N);
-        // System.out.println(toHexString(data));
-        MessageDigest hasher = MessageDigest.getInstance("md5");
-        hasher.update(data);
-        String hash = toHexString(hasher.digest());
-        System.out.println(hash);
-    }
+		byte[] data = new byte[N * chunkSize];
+		for (int y = 0; y < N; y++) {
+			var ci = y * inv - 1.0;
 
-    static final byte mbrot8(final double[] cr, final double civ) {
-        var ci = new double[] { civ, civ, civ, civ, civ, civ, civ, civ, };
-        var zr = new double[8];
-        var zi = new double[8];
-        var tr = new double[8];
-        var ti = new double[8];
-        var absz = new double[8];
-        var tmp = new double[8];
-        for (var _i = 0; _i < 10; _i++) {
-            IntStream.range(0, 5).forEach(_j -> {
-                add(zr, zr, tmp);
-                mul(tmp, zi, tmp);
-                add(tmp, ci, zi);
+			var yc = y * chunkSize;
+			for (int x = 0; x < chunkSize; x++) {
+				data[yc + x] = mbrot8(xloc[x], ci);
+			}
+		}
 
-                minus(tr, ti, tmp);
-                add(tmp, cr, zr);
+		System.out.println("P4\n" + N + " " + N);
+		// System.out.println(toHexString(data));
+		MessageDigest hasher = MessageDigest.getInstance("md5");
+		hasher.update(data);
+		String hash = toHexString(hasher.digest());
+		System.out.println(hash);
+	}
 
-                mul(zr, zr, tr);
-                mul(zi, zi, ti);
-            });
-            add(tr, ti, absz);
-            var terminate = true;
-            for (var i = 0; i < 8; i++) {
-                if (absz[i] <= 4.0) {
-                    terminate = false;
-                    break;
-                }
-            }
-            if (terminate) {
-                return 0;
-            }
-        }
+	static final byte mbrot8(final double[] cr, final double civ) {
+		var ci = new double[] { civ, civ, civ, civ, civ, civ, civ, civ, };
+		var zr = new double[8];
+		var zi = new double[8];
+		var tr = new double[8];
+		var ti = new double[8];
+		var absz = new double[8];
+		var tmp = new double[8];
 
-        var accu = (byte) 0;
-        for (var i = 0; i < 8; i++) {
-            if (absz[i] <= 4.0) {
-                accu |= 0x80 >> i;
-            }
-        }
-        return accu;
-    }
+		for (var _i = 0; _i < 10; _i++) {
+			for (var _j = 0; _j < 5; _j++) {
+				add(zr, zr, tmp);
+				mul(tmp, zi, tmp);
+				add(tmp, ci, zi);
 
-    static final void add(final double[] a, final double[] b, double[] r) {
-        IntStream.range(0, 8).forEach(i -> {
-            r[i] = a[i] + b[i];
-        });
-    }
+				minus(tr, ti, tmp);
+				add(tmp, cr, zr);
 
-    static final void minus(final double[] a, final double[] b, double[] r) {
-        IntStream.range(0, 8).forEach(i -> {
-            r[i] = a[i] - b[i];
-        });
-    }
+				mul(zr, zr, tr);
+				mul(zi, zi, ti);
+			}
+			add(tr, ti, absz);
+			
+			var terminate = true;
+			for (var i = 0; i < 8; i++) {
+				if (absz[i] <= 4.0) {
+					terminate = false;
+					break;
+				}
+			}
+			
+			if (terminate) {
+				return 0;
+			}
+		}
 
-    static final void mul(final double[] a, final double[] b, double[] r) {
-        IntStream.range(0, 8).forEach(i -> {
-            r[i] = a[i] * b[i];
-        });
-    }
+		var accu = (byte) 0;
+		for (var i = 0; i < 8; i++) {
+			if (absz[i] <= 4.0) {
+				accu |= 0x80 >> i;
+			}
+		}
+		return accu;
+	}
 
-    static final String toHexString(byte[] a) {
-        StringBuilder sb = new StringBuilder(a.length * 2);
-        for (byte b : a)
-            sb.append(String.format("%02x", b));
-        return sb.toString();
-    }
+	static final void add(final double[] a, final double[] b, double[] r) {
+		for (int i = 0; i < 8; i++) {
+			r[i] = a[i] + b[i];
+		}
+	}
+
+	static final void minus(final double[] a, final double[] b, double[] r) {
+		for (int i = 0; i < 8; i++) {
+			r[i] = a[i] - b[i];
+		}
+	}
+
+	static final void mul(final double[] a, final double[] b, double[] r) {
+		for (int i = 0; i < 8; i++) {
+			r[i] = a[i] * b[i];
+		}
+	}
+
+	static final String toHexString(byte[] a) {
+		final StringBuilder sb = new StringBuilder(a.length * 2);
+		for (final byte b : a) {
+			sb.append(String.format("%02x", b));
+		}
+		
+		return sb.toString();
+	}
 }

--- a/bench/algorithm/mandelbrot/1a.java
+++ b/bench/algorithm/mandelbrot/1a.java
@@ -1,0 +1,121 @@
+import java.io.*;
+import java.security.*;
+import java.util.Arrays;
+import java.util.stream.*;
+
+/**
+ * Variantion of 1.java but with 10x less memory needs due to
+ * reuse of the arrays instead of reallocation them over and over
+ */
+public final class app {
+	public static void main(String[] args) throws Exception {
+		int N = 100;
+		if (args.length >= 1) {
+			N = Integer.parseInt(args[0]);
+		}
+
+		N = (N + 7) / 8 * 8;
+		int chunkSize = N / 8;
+		double inv = 2.0 / N;
+
+		var xloc = new double[chunkSize][8];
+		for (int i = 0; i < N; i++) {
+			xloc[i / 8][i % 8] = inv * i - 1.5;
+		}
+
+		byte[] data = new byte[N * chunkSize];
+		for (int y = 0; y < N; y++) {
+			var ci = y * inv - 1.0;
+
+			var yc = y * chunkSize;
+			for (int x = 0; x < chunkSize; x++) {
+				data[yc + x] = mbrot8(xloc[x], ci);
+			}
+		}
+
+		System.out.println("P4\n" + N + " " + N);
+		// System.out.println(toHexString(data));
+		MessageDigest hasher = MessageDigest.getInstance("md5");
+		hasher.update(data);
+		String hash = toHexString(hasher.digest());
+		System.out.println(hash);
+	}
+
+	static double[] ci = new double[8];
+	static double[] zr = new double[8];
+	static double[] zi = new double[8];
+	static double[] tr = new double[8];
+	static double[] ti = new double[8];
+	static double[] absz = new double[8];
+	static double[] tmp = new double[8];
+	
+	static final byte mbrot8(final double[] cr, final double civ) {
+		// don't allocate new memory, just zero or init it
+		for ( int i = 0; i < 8; i++) {
+			ci[i] = civ;
+			zr[i] = zi[i] = tr[i] = ti[i] = absz[i] = tmp[i] = 0.0;			
+		}
+		
+		for (var _i = 0; _i < 10; _i++) {
+			for (var _j = 0; _j < 5; _j++) {
+				add(zr, zr, tmp);
+				mul(tmp, zi, tmp);
+				add(tmp, ci, zi);
+
+				minus(tr, ti, tmp);
+				add(tmp, cr, zr);
+
+				mul(zr, zr, tr);
+				mul(zi, zi, ti);
+			}
+			add(tr, ti, absz);
+			
+			var terminate = true;
+			for (var i = 0; i < 8; i++) {
+				if (absz[i] <= 4.0) {
+					terminate = false;
+					break;
+				}
+			}
+			
+			if (terminate) {
+				return 0;
+			}
+		}
+
+		var accu = (byte) 0;
+		for (var i = 0; i < 8; i++) {
+			if (absz[i] <= 4.0) {
+				accu |= 0x80 >> i;
+			}
+		}
+		return accu;
+	}
+
+	static final void add(final double[] a, final double[] b, double[] r) {
+		for (int i = 0; i < 8; i++) {
+			r[i] = a[i] + b[i];
+		}
+	}
+
+	static final void minus(final double[] a, final double[] b, double[] r) {
+		for (int i = 0; i < 8; i++) {
+			r[i] = a[i] - b[i];
+		}
+	}
+
+	static final void mul(final double[] a, final double[] b, double[] r) {
+		for (int i = 0; i < 8; i++) {
+			r[i] = a[i] * b[i];
+		}
+	}
+
+	static final String toHexString(byte[] a) {
+		final StringBuilder sb = new StringBuilder(a.length * 2);
+		for (final byte b : a) {
+			sb.append(String.format("%02x", b));
+		}
+		
+		return sb.toString();
+	}
+}

--- a/bench/algorithm/mandelbrot/1b.java
+++ b/bench/algorithm/mandelbrot/1b.java
@@ -1,0 +1,109 @@
+import java.io.*;
+import java.security.*;
+import java.util.Arrays;
+import java.util.stream.*;
+
+/**
+ * Variantion of 1a.java with further saving in terms of memory
+ * access and loop count
+ */
+public final class app {
+	public static void main(String[] args) throws Exception {
+		int N = 100;
+		if (args.length >= 1) {
+			N = Integer.parseInt(args[0]);
+		}
+
+		N = (N + 7) / 8 * 8;
+		int chunkSize = N / 8;
+		double inv = 2.0 / N;
+
+		var xloc = new double[chunkSize][8];
+		for (int i = 0; i < N; i++) {
+			xloc[i / 8][i % 8] = inv * i - 1.5;
+		}
+
+		// this brings the memory into a local context instead of a global
+		// which makes it faster (compare 1a,java)
+		double[] ci = new double[8];
+		double[] zr = new double[8];
+		double[] zi = new double[8];
+		double[] tr = new double[8];
+		double[] ti = new double[8];
+		double[] absz = new double[8];
+		
+		byte[] data = new byte[N * chunkSize];
+		for (int y = 0; y < N; y++) {
+			var civ = y * inv - 1.0;
+
+			var yc = y * chunkSize;
+			for (int x = 0; x < chunkSize; x++) {
+				data[yc + x] = mbrot8(ci, zr, zi, tr, ti, absz, xloc[x], civ);
+			}
+		}
+
+		System.out.println("P4\n" + N + " " + N);
+		// System.out.println(toHexString(data));
+		
+		MessageDigest hasher = MessageDigest.getInstance("md5");
+		hasher.update(data);
+		
+		// this avoid to load a StringBuilder which we really don't need here
+		// because this output is small
+		for (final byte b : hasher.digest()) {
+			System.out.print(String.format("%02x", b));
+		}
+		System.out.println();
+	}
+
+	static final byte mbrot8(
+			double[] ci,
+			double[] zr,
+			double[] zi,
+			double[] tr,
+			double[] ti,
+			double[] absz,
+			final double[] cr, final double civ) {
+		// don't allocate new memory, just zero or init it
+		for ( int i = 0; i < 8; i++) {
+			ci[i] = civ;
+			zr[i] = zi[i] = tr[i] = ti[i] = absz[i] = 0.0;			
+		}
+		
+		for (var _i = 0; _i < 10; _i++) {
+			for (var _j = 0; _j < 5; _j++) {
+				for (int i = 0; i < 8; i++) {
+					zi[i] = ((zr[i] + zr[i]) * zi[i]) + ci[i];
+					
+					zr[i] = tr[i] - ti[i] + cr[i];
+					
+					tr[i] = zr[i] * zr[i];
+					ti[i] = zi[i] * zi[i];
+				}
+			}
+			for (int i = 0; i < 8; i++) {
+				absz[i] = tr[i] + ti[i];
+			}
+			
+			var terminate = true;
+			for (var i = 0; i < 8; i++) {
+				if (absz[i] <= 4.0) {
+					terminate = false;
+					break;
+				}
+			}
+			
+			if (terminate) {
+				return 0;
+			}
+		}
+
+		var accu = (byte) 0;
+		for (var i = 0; i < 8; i++) {
+			if (absz[i] <= 4.0) {
+				accu |= 0x80 >> i;
+			}
+		}
+		return accu;
+	}
+}

--- a/bench/bench_java.yaml
+++ b/bench/bench_java.yaml
@@ -34,6 +34,8 @@ problems:
   - name: mandelbrot
     source:
       - 1.java
+      - 1a.java
+      - 1b.java
       - 2.java
   - name: spectral-norm
     source:


### PR DESCRIPTION
* 1.java was changed to avoid using Stream, runtime goes down from 10 sec to less than 2 sec on my machine
* 1a.java improves the memory usage from 345 MB peak to 45 MB peak and lowers the runtime a little
* 1b.java changes the code heavily to avoid some storage operations and takes the "shared" memory local, reduces the runtime to less than a one sec on my machine