### PR TITLE
Optimization of python nbody

### DIFF
--- a/bench/algorithm/nbody/2.py
+++ b/bench/algorithm/nbody/2.py
@@ -1,8 +1,8 @@
 import sys
-import math
+from itertools import combinations
 
 
-class Body(object):
+class Body:
     def __init__(self, p, v, m):
         (self.x, self.y, self.z) = p
         (self.vx, self.vy, self.vz) = v
@@ -52,44 +52,40 @@ N_BODIES = len(SYSTEM)
 
 
 def advance(dt, bodies=SYSTEM):
-    for i in range(N_BODIES):
-        b1 = bodies[i]
-        for j in range(i+1, N_BODIES):
-            b2 = bodies[j]
-            dx = b1.x - b2.x
-            dy = b1.y - b2.y
-            dz = b1.z - b2.z
+    for b1, b2 in combinations(bodies, r=2):
+        dx = b1.x - b2.x
+        dy = b1.y - b2.y
+        dz = b1.z - b2.z
 
-            d_squared = dx*dx + dy*dy + dz*dz
-            distance = math.sqrt(d_squared)
+        d_squared = dx * dx + dy * dy + dz * dz
 
-            mag = dt / (d_squared * distance)
+        mag = dt / d_squared**1.5
 
-            m2_multi_mag = b2.m * mag
-            b1.vx -= dx * m2_multi_mag
-            b1.vy -= dy * m2_multi_mag
-            b1.vz -= dz * m2_multi_mag
+        m2_multi_mag = b2.m * mag
+        b1.vx -= dx * m2_multi_mag
+        b1.vy -= dy * m2_multi_mag
+        b1.vz -= dz * m2_multi_mag
 
-            m1_multi_mag = b1.m * mag
-            b2.vx += dx * m1_multi_mag
-            b2.vy += dy * m1_multi_mag
-            b2.vz += dz * m1_multi_mag
-        b1.x += dt * b1.vx
-        b1.y += dt * b1.vy
-        b1.z += dt * b1.vz
+        m1_multi_mag = b1.m * mag
+        b2.vx += dx * m1_multi_mag
+        b2.vy += dy * m1_multi_mag
+        b2.vz += dz * m1_multi_mag
+
+    for b in bodies:
+        b.x += dt * b.vx
+        b.y += dt * b.vy
+        b.z += dt * b.vz
 
 
 def report_energy(bodies=SYSTEM, e=0.0):
-    for i in range(N_BODIES):
-        b1 = bodies[i]
-        e += 0.5 * b1.m * (b1.vx * b1.vx + b1.vy * b1.vy + b1.vz * b1.vz)
-        for j in range(i + 1, N_BODIES):
-            b2 = bodies[j]
-            dx = b1.x - b2.x
-            dy = b1.y - b2.y
-            dz = b1.z - b2.z
-            distance = math.sqrt(dx*dx + dy*dy + dz*dz)
-            e -= b1.m * b2.m / distance
+    for b1, b2 in combinations(bodies, r=2):
+        dx = b1.x - b2.x
+        dy = b1.y - b2.y
+        dz = b1.z - b2.z
+        distance = (dx * dx + dy * dy + dz * dz) ** 0.5
+        e -= b1.m * b2.m / distance
+    for b in bodies:
+        e += 0.5 * b.m * (b.vx * b.vx + b.vy * b.vy + b.vz * b.vz)
     print("%.9f" % e)
 
 


### PR DESCRIPTION
Hi there!

I was poking around and figured I could speed this code up a smidge. The base python package `math` is sometimes slower than you may expect, for example, the sqrt of a number is usually much faster if you use `**0.5` instead of `sqrt`. 
<img width="257" alt="image" src="https://user-images.githubusercontent.com/8423587/177457727-cf03c972-7280-4e9c-829d-2aca49af5747.png">

Additionally part of the computation was doing an effective `x ^ 3/2` in 2 steps, and switching to `x**1.5` gets a similar speedup to above ^.


Also, the double `for` loops over a range with the lookups adds a fair amount of time. This PR switches to using the base python `combinations` which achieves the same goal a tiny bit faster, and I would argue more read-ably.

I didnt run everything else on my machine, but just running this specific section of code in python I got around a 15% speedup.

Let me know if you want me to put this somewhere else.

