### PR TITLE
zig - get merkletrees and binarytrees working, prevent overflow in lru

### DIFF
--- a/bench/algorithm/binarytrees/1.zig
+++ b/bench/algorithm/binarytrees/1.zig
@@ -53,7 +53,7 @@ const Node = struct {
 
     pub fn init(allocator: Allocator) !*Self {
         var node = try allocator.create(Self);
-        node.allocator = allocator;
+        node.* = .{ .allocator = allocator };
         return node;
     }
 

--- a/bench/algorithm/lru/1.zig
+++ b/bench/algorithm/lru/1.zig
@@ -54,7 +54,7 @@ const LCG = struct {
         const A: u32 = comptime 1103515245;
         const C: u32 = comptime 12345;
         const M: u32 = comptime 1 << 31;
-        self.seed = (A * self.seed + C) % M;
+        self.seed = (A *% self.seed +% C) % M;
         return self.seed;
     }
 };
@@ -76,7 +76,7 @@ fn LinkedList(comptime T: type) type {
 
         pub fn init(allocator: Allocator) !*Self {
             var list = try allocator.create(Self);
-            list.allocator = allocator;
+            list.* = .{ .allocator = allocator };
             return list;
         }
 
@@ -92,7 +92,7 @@ fn LinkedList(comptime T: type) type {
 
         pub fn add(self: *Self, data: T) !*Node {
             var node = try self.allocator.create(Node);
-            node.data = data;
+            node.* = .{ .data = data };
             self.__add_node(node);
             self.len += 1;
             return node;
@@ -156,11 +156,13 @@ fn LRU(
 
         pub fn init(size: u32, allocator: Allocator) !*Self {
             var lru = try allocator.create(Self);
-            lru.allocator = allocator;
-            lru.size = size;
-            lru.keys = MapType.init(allocator);
+            lru.* = .{
+                .allocator = allocator,
+                .size = size,
+                .keys = MapType.init(allocator),
+                .entries = try ListType.init(allocator),
+            };
             try lru.keys.ensureTotalCapacity(size);
-            lru.entries = try ListType.init(allocator);
             return lru;
         }
 

--- a/bench/algorithm/merkletrees/1.zig
+++ b/bench/algorithm/merkletrees/1.zig
@@ -57,7 +57,7 @@ const Node = struct {
 
     pub fn init(allocator: Allocator) !*Self {
         var node = try allocator.create(Self);
-        node.allocator = allocator;
+        node.* = .{ .allocator = allocator };
         return node;
     }
 


### PR DESCRIPTION
- fixes segfaults and integer overflows in 3 of the zig
  solutions found by running them in safe build modes.
- merkletrees and binarytrees/1.zig solutions were timing out so i ran
  them and discovered segfaults.  also noticed an integer overflow in
  lru/1.zig.
- this patch uses the `var.* = .{...}` pattern to initialize newly
  allocated memory. this allows the compiler to enforce that all fields
  are initialized.
- overflow error was fixed by using wrapping arithmetic operators: +%/*%.
  i assume it is correct as they behave the same as +/* in c.
- compiled with zig version 0.10.0-dev.2880+6f0807f50 (same version as shown
  here https://programming-language-benchmarks.vercel.app/rust-vs-zig)