### PR TITLE
zig pidigits - audit memory usage

### DIFF
--- a/bench/algorithm/pidigits/1.zig
+++ b/bench/algorithm/pidigits/1.zig
@@ -11,26 +11,20 @@ pub fn main() !void {
     const two = (try bigint.Managed.initSet(global_allocator, 2));
     const ten = (try bigint.Managed.initSet(global_allocator, 10));
 
-    var lbuf: [10]std.math.big.Limb = undefined;
-    // 320 kb seems to be around the minimum required size for this solution
-    var bigbuf: [1024 * (64 * 5)]u8 = undefined;
-    var fba = std.heap.FixedBufferAllocator.init(&bigbuf);
-    const fixed_allocator = fba.allocator();
-
-    var k: usize = 1;
+    var k = try bigint.Managed.initSet(global_allocator, 1);
     var n1 = try bigint.Managed.initSet(global_allocator, 4);
     var n2 = try bigint.Managed.initSet(global_allocator, 3);
     var d = try bigint.Managed.initSet(global_allocator, 1);
+    var tmp = try bigint.Managed.init(global_allocator);
+    var tmp2 = try bigint.Managed.init(global_allocator);
+    var v = try bigint.Managed.init(global_allocator);
+    var u = try bigint.Managed.init(global_allocator);
+    var w = try bigint.Managed.init(global_allocator);
 
     var digits_printed: usize = 0;
+    var lbuf: [10]std.math.big.Limb = undefined;
     var sb: [10]u8 = undefined;
     while (true) {
-        fba.end_index = 0;
-        var tmp = try bigint.Managed.init(fixed_allocator);
-        var tmp2 = try bigint.Managed.init(fixed_allocator);
-        var v = try bigint.Managed.init(fixed_allocator);
-        var u = try bigint.Managed.init(fixed_allocator);
-
         // u = &n1 / &d;
         try bigint.Managed.divFloor(&u, &tmp, &n1, &d);
         // v = &n2 / &d;
@@ -40,9 +34,8 @@ pub fn main() !void {
             const rem = @rem(digits_printed, 10);
             _ = u.toConst().toString(sb[rem..], 10, .lower, &lbuf);
             digits_printed += 1;
-            if (rem == 9) {
+            if (rem == 9)
                 try stdout.print("{s}\t:{d}\n", .{ sb, digits_printed });
-            }
 
             if (digits_printed >= n) {
                 if (rem != 9) {
@@ -61,21 +54,20 @@ pub fn main() !void {
             try bigint.Managed.mul(&tmp, &n2, &ten);
             try bigint.Managed.sub(&n2, &tmp, &tmp2);
         } else {
-            var w = try bigint.Managed.init(fixed_allocator);
             // let k2 = &k * &two;
-            try tmp2.set(k * 2);
+            try bigint.Managed.mul(&tmp2, &k, &two);
             // u = &n1 * (&k2 - &one);
             try bigint.Managed.sub(&tmp, &tmp2, &one);
             try bigint.Managed.mul(&u, &tmp, &n1);
             // v = &n2 * &two;
             try bigint.Managed.mul(&v, &n2, &two);
             // w = &n1 * (&k - &one);
-            try tmp.set(k - 1);
+            try bigint.Managed.sub(&tmp, &k, &one);
             try bigint.Managed.mul(&w, &tmp, &n1);
             // n1 = &u + &v;
             try bigint.Managed.add(&n1, &u, &v);
             // u = &n2 * (&k + &two);
-            try tmp.set(k + 2);
+            try bigint.Managed.add(&tmp, &k, &two);
             try bigint.Managed.mul(&u, &tmp, &n2);
             // n2 = &w + &u;
             try bigint.Managed.add(&n2, &w, &u);
@@ -83,7 +75,7 @@ pub fn main() !void {
             try bigint.Managed.add(&tmp, &tmp2, &one);
             try bigint.Managed.mul(&d, &tmp, &d);
             // k = &k + &one;
-            k += 1;
+            try bigint.Managed.add(&k, &k, &one);
         }
     }
 }

--- a/bench/algorithm/pidigits/1.zig
+++ b/bench/algorithm/pidigits/1.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const bigint = std.math.big.int;
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-var global_allocator = gpa.allocator();
+const global_allocator = gpa.allocator();
 
 pub fn main() !void {
     const stdout = std.io.getStdOut().writer();
@@ -11,34 +11,34 @@ pub fn main() !void {
     const two = (try bigint.Managed.initSet(global_allocator, 2));
     const ten = (try bigint.Managed.initSet(global_allocator, 10));
 
-    var k = try bigint.Managed.initSet(global_allocator, 1);
+    var lbuf: [10]std.math.big.Limb = undefined;
+    // 320 kb seems to be around the minimum required size for this solution
+    var bigbuf: [1024 * (64 * 5)]u8 = undefined;
+    var fba = std.heap.FixedBufferAllocator.init(&bigbuf);
+    const fixed_allocator = fba.allocator();
+
+    var k: usize = 1;
     var n1 = try bigint.Managed.initSet(global_allocator, 4);
     var n2 = try bigint.Managed.initSet(global_allocator, 3);
     var d = try bigint.Managed.initSet(global_allocator, 1);
-    var u = try bigint.Managed.init(global_allocator);
-    var v = try bigint.Managed.init(global_allocator);
-    var w = try bigint.Managed.init(global_allocator);
 
     var digits_printed: usize = 0;
-    var sb = [10:0]u8{ ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ' };
+    var sb: [10]u8 = undefined;
     while (true) {
+        fba.end_index = 0;
+        var tmp = try bigint.Managed.init(fixed_allocator);
+        var tmp2 = try bigint.Managed.init(fixed_allocator);
+        var v = try bigint.Managed.init(fixed_allocator);
+        var u = try bigint.Managed.init(fixed_allocator);
+
         // u = &n1 / &d;
-        {
-            var tmp = try bigint.Managed.init(global_allocator);
-            defer tmp.deinit();
-            try bigint.Managed.divFloor(&u, &tmp, &n1, &d);
-        }
+        try bigint.Managed.divFloor(&u, &tmp, &n1, &d);
         // v = &n2 / &d;
-        {
-            var tmp = try bigint.Managed.init(global_allocator);
-            defer tmp.deinit();
-            try bigint.Managed.divFloor(&v, &tmp, &n2, &d);
-        }
+        try bigint.Managed.divFloor(&v, &tmp, &n2, &d);
         // if u == v
         if (bigint.Managed.eq(u, v)) {
-            var digitStr = try u.toString(global_allocator, 10, std.fmt.Case.lower);
             const rem = @rem(digits_printed, 10);
-            sb[rem] = digitStr[0];
+            _ = u.toConst().toString(sb[rem..], 10, .lower, &lbuf);
             digits_printed += 1;
             if (rem == 9) {
                 try stdout.print("{s}\t:{d}\n", .{ sb, digits_printed });
@@ -46,99 +46,44 @@ pub fn main() !void {
 
             if (digits_printed >= n) {
                 if (rem != 9) {
-                    var i = rem + 1;
-                    while (i < 10) {
-                        sb[i] = ' ';
-                        i += 1;
-                    }
+                    std.mem.set(u8, sb[rem + 1 ..], ' ');
                     try stdout.print("{s}\t:{d}\n", .{ sb, digits_printed });
                 }
                 break;
             }
-
             // let to_minus = &u * &ten * &d;
-            var to_minus_managed = try bigint.Managed.init(global_allocator);
-            defer to_minus_managed.deinit();
-            {
-                var tmp = try bigint.Managed.init(global_allocator);
-                defer tmp.deinit();
-                try bigint.Managed.mul(&tmp, &u, &d);
-                try bigint.Managed.mul(&to_minus_managed, &tmp, &ten);
-            }
-
+            try bigint.Managed.mul(&tmp, &u, &d);
+            try bigint.Managed.mul(&tmp2, &tmp, &ten);
             // n1 = &n1 * &ten - &to_minus;
-            {
-                var tmp = try bigint.Managed.init(global_allocator);
-                defer tmp.deinit();
-                try bigint.Managed.mul(&tmp, &n1, &ten);
-                try bigint.Managed.sub(&n1, &tmp, &to_minus_managed);
-            }
+            try bigint.Managed.mul(&tmp, &n1, &ten);
+            try bigint.Managed.sub(&n1, &tmp, &tmp2);
             // n2 = &n2 * &ten - &to_minus;
-            {
-                var tmp = try bigint.Managed.init(global_allocator);
-                defer tmp.deinit();
-                try bigint.Managed.mul(&tmp, &n2, &ten);
-                try bigint.Managed.sub(&n2, &tmp, &to_minus_managed);
-            }
+            try bigint.Managed.mul(&tmp, &n2, &ten);
+            try bigint.Managed.sub(&n2, &tmp, &tmp2);
         } else {
+            var w = try bigint.Managed.init(fixed_allocator);
             // let k2 = &k * &two;
-            var k2 = try bigint.Managed.init(global_allocator);
-            defer k2.deinit();
-            try bigint.Managed.mul(&k2, &k, &two);
+            try tmp2.set(k * 2);
             // u = &n1 * (&k2 - &one);
-            {
-                var tmp = try bigint.Managed.init(global_allocator);
-                defer tmp.deinit();
-                try bigint.Managed.sub(&tmp, &k2, &one);
-                var tmpu = try bigint.Managed.init(global_allocator);
-                try bigint.Managed.mul(&tmpu, &tmp, &n1);
-                u.deinit();
-                u = tmpu;
-            }
+            try bigint.Managed.sub(&tmp, &tmp2, &one);
+            try bigint.Managed.mul(&u, &tmp, &n1);
             // v = &n2 * &two;
-            {
-                var tmpv = try bigint.Managed.init(global_allocator);
-                try bigint.Managed.mul(&tmpv, &n2, &two);
-                v.deinit();
-                v = tmpv;
-            }
+            try bigint.Managed.mul(&v, &n2, &two);
             // w = &n1 * (&k - &one);
-            {
-                var tmp = try bigint.Managed.init(global_allocator);
-                defer tmp.deinit();
-                try bigint.Managed.sub(&tmp, &k, &one);
-                var tmpw = try bigint.Managed.init(global_allocator);
-                try bigint.Managed.mul(&tmpw, &tmp, &n1);
-                w.deinit();
-                w = tmpw;
-            }
+            try tmp.set(k - 1);
+            try bigint.Managed.mul(&w, &tmp, &n1);
             // n1 = &u + &v;
             try bigint.Managed.add(&n1, &u, &v);
             // u = &n2 * (&k + &two);
-            {
-                var tmp = try bigint.Managed.init(global_allocator);
-                defer tmp.deinit();
-                try bigint.Managed.add(&tmp, &k, &two);
-                var tmpu = try bigint.Managed.init(global_allocator);
-                try bigint.Managed.mul(&tmpu, &tmp, &n2);
-                u.deinit();
-                u = tmpu;
-            }
+            try tmp.set(k + 2);
+            try bigint.Managed.mul(&u, &tmp, &n2);
             // n2 = &w + &u;
             try bigint.Managed.add(&n2, &w, &u);
             // d = &d * (&k2 + &one);
-            {
-                var tmp1 = try bigint.Managed.init(global_allocator);
-                defer tmp1.deinit();
-                try bigint.Managed.add(&tmp1, &k2, &one);
-                var tmpd = try bigint.Managed.init(global_allocator);
-                try bigint.Managed.mul(&tmpd, &tmp1, &d);
-                d.deinit();
-                d = tmpd;
-            }
-
+            try bigint.Managed.add(&tmp, &tmp2, &one);
+            try bigint.Managed.mul(&d, &tmp, &d);
             // k = &k + &one;
-            try bigint.Managed.add(&k, &k, &one);
+            k += 1;
         }
     }
 }


### PR DESCRIPTION
- generally clean up this solution which was allocating a lot of
  extra temporary bigints.
- don't bother deinit()ing anything
- use a 320kb fixed buffer allocator for temporary values
- k doesn't need to be a bigint