### PR TITLE
`1.dart`: fix `Stream` and `yield` usage

### DIFF
--- a/bench/algorithm/coro-prime-sieve/1.dart
+++ b/bench/algorithm/coro-prime-sieve/1.dart
@@ -1,19 +1,25 @@
 import 'dart:async';
 
 Future main(List<String> arguments) async {
-  final n = arguments.length > 0 ? int.parse(arguments[0]) : 5;
+  final n = arguments.isNotEmpty ? int.parse(arguments[0]) : 5;
+
   var stream = StreamIterator(generate());
+
   for (var i = 0; i < n; i++) {
-    await stream.moveNext();
-    var prime = stream.current;
-    print(prime);
-    stream = StreamIterator(filter(stream, prime));
+    if (await stream.moveNext()) {
+      var prime = stream.current;
+      print(prime);
+
+      stream = StreamIterator(filter(stream, prime));
+    } else {
+      break;
+    }
   }
 }
 
 Stream<int> generate() async* {
   for (var i = 2;; i++) {
-    yield await Future.microtask(() => i);
+    yield i;
   }
 }
 
@@ -21,7 +27,7 @@ Stream<int> filter(StreamIterator<int> input, int prime) async* {
   while (await input.moveNext()) {
     final i = input.current;
     if (i % prime != 0) {
-      yield await Future.microtask(() => i);
+      yield i;
     }
   }
 }


### PR DESCRIPTION
The previous code was using `yield` in a wrong (or outdated) form, creating unnecessary `Future` + `lambda` and unnecessary use of `await`.