### PR TITLE
Use proper OCaml name for programming language

### DIFF
--- a/website/contentUtils.ts
+++ b/website/contentUtils.ts
@@ -6,6 +6,7 @@ const lang2Display: { [key: string]: string } = {
   csharp: 'C#',
   cpp: 'C++',
   hacklang: 'Hack',
+  ocaml: 'OCaml',
 }
 
 export async function getLangBenchResults($content: contentFunc) {


### PR DESCRIPTION
OCaml is now canonically called "OCaml" with an upper case `C`, so add this to the configuration.