### PR TITLE
Use manual memory management for Nim binary trees

### DIFF
--- a/bench/algorithm/binarytrees/3.nim
+++ b/bench/algorithm/binarytrees/3.nim
@@ -1,0 +1,54 @@
+
+import std/[os, strutils]
+
+type Node {.acyclic.} = object
+  le: ptr Node
+  ri: ptr Node
+  
+proc bottomUpTree(depth: int): ptr Node =
+  if depth > 0:
+    result = cast[ptr Node](alloc(sizeof(Node)))
+    result.le = bottomUpTree(depth-1)
+    result.ri = bottomUpTree(depth-1)
+  else:
+    result = cast[ptr Node](alloc(sizeof(Node)))
+    result.le = nil
+    result.ri = nil
+    
+
+proc check(n: ptr Node): int =
+  result = 1
+  if n.le != nil:
+    result += n.le.check() + n.ri.check()    
+    dealloc(cast[pointer](n.le))
+    dealloc(cast[pointer](n.ri))
+    n.le = nil
+    n.ri = nil  
+            
+
+proc main() =
+  const minDepth = 4
+  let maxDepth =
+    if paramCount() > 0:
+      max(minDepth+2, paramStr(1).parseInt)
+    else: 6
+
+  block:
+    let depth = maxDepth + 1
+    let sTree = bottomUpTree(depth)
+    echo "stretch tree of depth ", depth, "\t check: ", sTree.check()
+  let longLivedTree = bottomUpTree(maxDepth)
+
+  for d in countup(minDepth, maxDepth, 2):
+    let iterations = 1 shl (maxDepth - d + minDepth)
+    var checks = 0
+    for _ in 1..iterations:
+      let tree = bottomUpTree(d)
+      checks += tree.check()
+      dealloc(tree)
+    echo iterations, "\t trees of depth ", d, "\t check: ", checks
+
+  echo "long lived tree of depth ", maxDepth, "\t check: ", longLivedTree.check()
+
+when isMainModule:
+  main()

--- a/bench/bench_nim.yaml
+++ b/bench/bench_nim.yaml
@@ -40,6 +40,7 @@ problems:
     source:
       # - 1.nim
       - 2.nim
+      - 3.nim
   - name: merkletrees
     source:
       - 1.nim


### PR DESCRIPTION
Hi @hanabi1224, 

I would like to contribute some simple modifications to the 2.nim program to use manual memory management instead of the GC. The new version (3.nim) deallocates each node after it traverses any child nodes, and then deallocates the root nodes at the end of the traversal. It should still fit the description of the binary trees problem from [the other benchmarks game](https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/binarytrees.html#binarytrees). 

Let me know if any further modifications are necessary to meet the implementation guidelines. Thanks!