### PR TITLE
Yet another implementation of binarytrees in rust (using vector indices)

### DIFF
--- a/bench/algorithm/binarytrees/6.rs
+++ b/bench/algorithm/binarytrees/6.rs
@@ -1,0 +1,93 @@
+pub type TreeIndex = usize;
+
+#[derive(Clone, Copy)]
+struct TreeNode {
+    l: TreeIndex,
+    r: TreeIndex,
+}
+
+struct Tree {
+    nodes: Vec<TreeNode>,
+}
+
+impl Tree {
+    fn check(&self) -> i32 {
+        self.check_inner(self.nodes.len() - 1)
+    }
+
+    fn check_inner(&self, ix: usize) -> i32 {
+        let mut ret = 1;
+        let TreeNode { l, r } = self.nodes[ix];
+        if l > 0 {
+            ret += self.check_inner(l);
+        }
+        if r > 0 {
+            ret += self.check_inner(r);
+        }
+        ret
+    }
+
+    fn create(depth: usize) -> Self {
+        let mut tree = Tree {
+            nodes: Vec::with_capacity(1 << (depth + 1)),
+        };
+        tree.nodes.push(TreeNode { l: 0, r: 0 });
+        let root = TreeNode::new(depth, &mut tree);
+        assert_eq!(root + 1, tree.nodes.len());
+        tree
+    }
+}
+
+impl TreeNode {
+    fn new(depth: usize, tree: &mut Tree) -> TreeIndex {
+        if depth > 0 {
+            let n = TreeNode {
+                l: Self::new(depth - 1, tree),
+                r: Self::new(depth - 1, tree),
+            };
+            tree.nodes.push(n);
+            tree.nodes.len() - 1
+        } else {
+            tree.nodes.push(TreeNode { l: 0, r: 0 });
+            tree.nodes.len() - 1
+        }
+    }
+}
+
+const MIN_DEPTH: usize = 4;
+
+fn main() {
+    let n = std::env::args_os()
+        .nth(1)
+        .and_then(|s| s.into_string().ok())
+        .and_then(|n| n.parse().ok())
+        .unwrap_or(10);
+
+    let max_depth = if MIN_DEPTH + 2 > n { MIN_DEPTH + 2 } else { n };
+
+    {
+        let depth = max_depth + 1;
+        let tree = Tree::create(max_depth + 1);
+
+        println!("stretch tree of depth {}\t check: {}", depth, tree.check());
+    }
+
+    let long_lived_tree = Tree::create(max_depth);
+
+    for d in (MIN_DEPTH..max_depth + 1).step_by(2) {
+        let iterations = 1 << ((max_depth - d + MIN_DEPTH) as u32);
+        let mut chk = 0;
+        for _i in 0..iterations {
+            let a = Tree::create(d);
+            chk += a.check();
+        }
+        println!("{}\t trees of depth {}\t check: {}", iterations, d, chk)
+    }
+
+    println!(
+        "long lived tree of depth {}\t check: {}",
+        max_depth,
+        long_lived_tree.check()
+    );
+}
+

--- a/bench/bench_rust.yaml
+++ b/bench/bench_rust.yaml
@@ -8,6 +8,7 @@ problems:
       - 3.rs
       - 4.rs
       - 5.rs
+      - 6.rs
   - name: merkletrees
     source:
       - 1.rs


### PR DESCRIPTION
The borrow checker in rust brings extra complication to the construction of recursive data types (e.g., graph, tree, and yes, doubly linked list). There has been a long discussion [1,2,3,4] about the idiomatic representation of tree and graph data structures in Rust.

Compared to current existing versions of binarytrees (`{3,4,5}.rs`), this PR chooses an alternative representation for tree types: vector indices. Using vector indices can speed up the existing versions of binarytrees by times, as it internally makes the allocation an arena. Many details can be further slightly tuned, but the code should demonstrate the idea without making itself too long to read.

[[1]: Graphs and arena allocation](https://github.com/nrc/r4cppp/blob/master/graphs/README.md)
[[2]: Modeling graphs in Rust using vector indices](http://smallcultfollowing.com/babysteps/blog/2015/04/06/modeling-graphs-in-rust-using-vector-indices/)
[[3]: Idiomatic tree and graph like structures in Rust](https://rust-leipzig.github.io/architecture/2016/12/20/idiomatic-trees-in-rust/)
[[4]: petgraph review: internals](https://timothy.hobbs.cz/rust-play/petgraph-internals.html)