### PR TITLE
Use slice to speed up inner loop for python's nsieve benchmark

### DIFF
--- a/bench/algorithm/nsieve/2.py
+++ b/bench/algorithm/nsieve/2.py
@@ -1,0 +1,17 @@
+import sys
+
+
+def nsieve(n):
+    count = 0
+    flags = [True] * n
+    for i in range(2, n):
+        if flags[i]:
+            count += 1
+            flags[slice(i << 1, n, i)] = [False] * ((n - 1) // i - 1)
+    print(f'Primes up to {n:8} {count:8}')
+
+
+if __name__ == '__main__':
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 4
+    for i in range(0, 3):
+        nsieve(10000 << (n-i))

--- a/bench/bench_python.yaml
+++ b/bench/bench_python.yaml
@@ -45,6 +45,7 @@ problems:
   - name: nsieve
     source:
       - 1.py
+      - 2.py
   - name: lru
     source:
       - 1.py


### PR DESCRIPTION
Using slice syntax on the inner loop reduces the time by nearly half.

![image](https://user-images.githubusercontent.com/6608130/202774224-2d00229d-1fd8-4106-b431-28c02a2ae88f.png)

And both implementations produce the same output:

![image](https://user-images.githubusercontent.com/6608130/202774578-820cd316-3a18-4397-92e5-58950dbea1ab.png)
