### PR TITLE
Fix language links

### DIFF
--- a/website/components/LangMetaPage.vue
+++ b/website/components/LangMetaPage.vue
@@ -171,7 +171,11 @@
                   v-show="other || problem"
                   :class="['text-left', 'pl-4', mdHide]"
                 >
-                  <a :href="`/${i.lang}`">{{ i.lang }}</a>
+                  <a
+                    :href="`/${i.lang}`"
+                    class="underline text-blue-500"
+                    >{{ i.lang }}</a
+                  >
                 </td>
                 <td class="text-right">
                   <a


### PR DESCRIPTION
Currently lang links in comparison table have the same style as plain text:
![image](https://user-images.githubusercontent.com/4661021/210610960-250b16b7-593f-4d26-bea0-5ce0c9305540.png)

The only difference between this link and plain text is a cursor shape, which may be not so obvious.

Here I've changed link style to match the link of source code:
![image](https://user-images.githubusercontent.com/4661021/210611773-9a23679a-fb32-4d26-9f6b-fd511971d0a6.png)
