### PR TITLE
Keep CPU and memory measures in case of timeout

### DIFF
--- a/bench/bench.yaml
+++ b/bench/bench.yaml
@@ -1,6 +1,6 @@
 problems:
   - name: helloworld
-    trival: true
+    trivial: true
     unittests:
       - input: T_T
         output: T_T_out

--- a/bench/tool/ProcessUtils.cs
+++ b/bench/tool/ProcessUtils.cs
@@ -162,7 +162,7 @@ namespace BenchTool
             }
 
             ProcessMeasurement m = new ProcessMeasurement();
-            // TODO: Find better way to redirect stdout to /dev/null 
+            // TODO: Find better way to redirect stdout to /dev/null
             if (redirectStdoutToDevNull && s_isLinux)
             {
                 startInfo = new ProcessStartInfo
@@ -347,11 +347,20 @@ namespace BenchTool
                 env: env,
                 cts.Token,
                 onStart: () => manualResetEvent.Set()).ConfigureAwait(false);
+
             sw.Stop();
             cts.Cancel();
-            m.Elapsed = sw.Elapsed;
+
+            m.Elapsed = TimeSpan.FromMilliseconds(0);
+
+            // report run time only for successful runs
+            if (ret >= 0)
+            {
+                m.Elapsed = sw.Elapsed;
+            }
+
             await t.ConfigureAwait(false);
-            return ret < 0 ? null : m;
+            return m;
         }
 
         public static async Task RunCommandsAsync(
@@ -571,7 +580,7 @@ namespace BenchTool
                 {
                     // Avoid deadlock in sync mode
                     // https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standardoutput?view=net-5.0
-                    // To avoid deadlocks, use an asynchronous read operation on at least one of the streams.  
+                    // To avoid deadlocks, use an asynchronous read operation on at least one of the streams.
                     if (p.StartInfo.RedirectStandardError)
                     {
                         p.BeginErrorReadLine();

--- a/bench/tool/Program.cs
+++ b/bench/tool/Program.cs
@@ -691,21 +691,13 @@ namespace BenchTool
                         {
                             ProcessMeasurement measurement = await ProcessUtils.MeasureAsync(
                                 runPsi,
-                                redirectStdoutToDevNull: !problemTestConfig.Trival,
+                                redirectStdoutToDevNull: !problemTestConfig.Trivial,
                                 forceCheckChildProcesses: langEnvConfig.ForceCheckChildProcesses,
                                 timeoutSeconds: test.TimeoutSeconds,
                                 env: langEnvConfig.RunCmdEnv).ConfigureAwait(false);
 
-                            if (measurement != null && measurement.Elapsed.TotalMilliseconds > 0)
-                            {
-                                Logger.Debug($"({buildId}){langConfig.Lang}:{problem.Name}:{test.Input} {measurement}");
-                                measurements.Add(measurement);
-                            }
-                            else
-                            {
-                                measurements.Clear();
-                                break;
-                            }
+                            Logger.Debug($"({buildId}){langConfig.Lang}:{problem.Name}:{test.Input} {measurement}");
+                            measurements.Add(measurement);
                         }
                         catch (Exception e)
                         {

--- a/bench/tool/YamlLangConfig.cs
+++ b/bench/tool/YamlLangConfig.cs
@@ -26,7 +26,7 @@ namespace BenchTool
 
         public YamlBenchmarkProblemTestConfig[] Tests { get; set; }
 
-        public bool Trival { get; set; } = false;
+        public bool Trivial { get; set; } = false;
     }
 
     public class YamlBenchmarkProblemUnittestConfig


### PR DESCRIPTION
If benchmark is running too long, the process will be killed, and the site will show the entire row with zero values:
![image](https://user-images.githubusercontent.com/4661021/210613703-c14477b0-943c-4d81-82ea-d2d5229d8263.png)

However, CPU and memory usage are already saved, and can be useful so some cases. For example, to show that even if some language is not well suitable for a lot of computations, it does not require a lot of memory and CPU, and thus can be used on devices with low resources.

Here I've replaced throwing all the measures with zeroing just run time, but keeping CPU and memory information:
![image](https://user-images.githubusercontent.com/4661021/210615642-3f670d1b-cf12-4c96-9167-03bafb9bb56c.png)
