### PR TITLE
Record VM start time

### DIFF
--- a/bench/algorithm/binarytrees/1.py
+++ b/bench/algorithm/binarytrees/1.py
@@ -7,6 +7,7 @@
 # remove parallelization
 
 import sys
+from datetime import datetime
 
 
 def make_tree(d):
@@ -50,5 +51,8 @@ def main(n, min_depth=4):
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
+
     n = int(sys.argv[1]) if len(sys.argv) > 1 else 6
     main(n)

--- a/bench/algorithm/coro-prime-sieve/1.py
+++ b/bench/algorithm/coro-prime-sieve/1.py
@@ -1,5 +1,6 @@
 import sys
 import asyncio
+from datetime import datetime
 
 
 async def main():
@@ -24,5 +25,8 @@ async def filter(ch, prime):
             yield i
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
+
     sys.setrecursionlimit(5000)
     asyncio.run(main())

--- a/bench/algorithm/coro-prime-sieve/2.py
+++ b/bench/algorithm/coro-prime-sieve/2.py
@@ -1,5 +1,5 @@
 import sys
-
+from datetime import datetime
 
 def main():
     n = 100 if len(sys.argv) < 2 else int(sys.argv[1])
@@ -24,5 +24,8 @@ def filter(ch, prime):
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
+
     sys.setrecursionlimit(5000)
     main()

--- a/bench/algorithm/edigits/1.py
+++ b/bench/algorithm/edigits/1.py
@@ -1,5 +1,6 @@
 from sys import argv
 import math
+from datetime import datetime
 
 LN_TAU = math.log(math.tau)
 LN_10 = math.log(float(10))
@@ -53,4 +54,7 @@ def test_k(n, k):
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
+
     main()

--- a/bench/algorithm/fasta/1.py
+++ b/bench/algorithm/fasta/1.py
@@ -8,6 +8,7 @@
 
 import sys
 import bisect
+from datetime import datetime
 
 alu = (
     'GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGG'
@@ -88,4 +89,8 @@ def main():
     randomFasta(homosapiens, n*5)
 
 
-main()
+if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
+
+    main()

--- a/bench/algorithm/fasta/5-m.py
+++ b/bench/algorithm/fasta/5-m.py
@@ -10,6 +10,10 @@ from multiprocessing import Lock, RawValue, Process
 from os import cpu_count
 from re import sub
 from sys import argv, stdout
+from datetime import datetime
+
+with open("ready", "w") as f:
+    f.write(str(round(datetime.utcnow().timestamp() * 1000)))
 
 write = stdout.buffer.write
 
@@ -221,4 +225,7 @@ CCACTGCACTCCAGCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAA
 
 
 if __name__ == "__main__":
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
+
     fasta(int(argv[1]))

--- a/bench/algorithm/http-server/1.py
+++ b/bench/algorithm/http-server/1.py
@@ -3,9 +3,10 @@ import random
 import json
 import concurrent.futures
 import urllib.request
-from http.server import HTTPServer, ThreadingHTTPServer, BaseHTTPRequestHandler
+from http.server import HTTPServer, BaseHTTPRequestHandler
 from threading import Thread
 from io import BytesIO
+from datetime import datetime
 
 
 class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
@@ -48,4 +49,7 @@ def main():
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
+
     main()

--- a/bench/algorithm/http-server/2.py
+++ b/bench/algorithm/http-server/2.py
@@ -4,9 +4,10 @@ import json
 import concurrent.futures
 import urllib.request
 import uvicorn
-from http.server import HTTPServer, ThreadingHTTPServer, BaseHTTPRequestHandler
+from http.server import BaseHTTPRequestHandler
 from threading import Thread
 from io import BytesIO
+from datetime import datetime
 
 
 async def read_body(receive):
@@ -76,5 +77,8 @@ def main():
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
+
     main()
     # uvicorn.run("app:app", host="localhost", port=5000, log_level="info")

--- a/bench/algorithm/json-serde/1.py
+++ b/bench/algorithm/json-serde/1.py
@@ -2,6 +2,7 @@ import sys
 import codecs
 import json
 import hashlib
+from datetime import datetime
 
 
 def print_hash(obj):
@@ -23,4 +24,7 @@ def main():
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
+
     main()

--- a/bench/algorithm/knucleotide/3.py
+++ b/bench/algorithm/knucleotide/3.py
@@ -8,6 +8,7 @@ from os import cpu_count
 from collections import defaultdict
 from itertools import starmap, chain
 from multiprocessing import Pool
+from datetime import datetime
 
 lean_buffer = {}
 
@@ -185,5 +186,8 @@ def main():
     display(results, display_list(di_nucleotides), relative=True, sort=True)
     display(results, display_list(k_nucleotides), end='')
 
-if __name__=='__main__' :
+if __name__=='__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
+
     main()

--- a/bench/algorithm/lru/1.py
+++ b/bench/algorithm/lru/1.py
@@ -1,6 +1,6 @@
 import sys
 from collections import OrderedDict
-
+from datetime import datetime
 
 class LRU:
     def __init__(self, size: int):
@@ -55,4 +55,6 @@ def main():
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
     main()

--- a/bench/algorithm/lru/2.py
+++ b/bench/algorithm/lru/2.py
@@ -1,5 +1,5 @@
 import sys
-
+from datetime import datetime
 
 class LinkedListNode(object):
     def __init__(self, data):
@@ -105,4 +105,6 @@ def main():
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
     main()

--- a/bench/algorithm/merkletrees/1.py
+++ b/bench/algorithm/merkletrees/1.py
@@ -1,5 +1,5 @@
 import sys
-
+from datetime import datetime
 
 class Node(object):
     def __init__(self, value, left, right):
@@ -65,5 +65,7 @@ def main(n, min_depth=4):
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
     n = int(sys.argv[1]) if len(sys.argv) > 1 else 6
     main(n)

--- a/bench/algorithm/nbody/1.py
+++ b/bench/algorithm/nbody/1.py
@@ -7,6 +7,7 @@
 # 2to3
 
 import sys
+from datetime import datetime
 
 
 def combinations(l):
@@ -118,4 +119,6 @@ def main(n, ref='sun'):
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
     main(int(sys.argv[1]))

--- a/bench/algorithm/nbody/2.py
+++ b/bench/algorithm/nbody/2.py
@@ -1,6 +1,6 @@
 import sys
 import math
-
+from datetime import datetime
 
 class Body(object):
     def __init__(self, p, v, m):
@@ -112,4 +112,6 @@ def main(n, ref='sun'):
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
     main(int(sys.argv[1]))

--- a/bench/algorithm/nsieve/1.py
+++ b/bench/algorithm/nsieve/1.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import datetime
 
 
 def nsieve(n):
@@ -13,6 +14,8 @@ def nsieve(n):
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
     n = int(sys.argv[1]) if len(sys.argv) > 1 else 4
     for i in range(0, 3):
         nsieve(10000 << (n-i))

--- a/bench/algorithm/nsieve/2.py
+++ b/bench/algorithm/nsieve/2.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import datetime
 
 
 def nsieve(n):
@@ -12,6 +13,8 @@ def nsieve(n):
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
     n = int(sys.argv[1]) if len(sys.argv) > 1 else 4
     for i in range(0, 3):
         nsieve(10000 << (n-i))

--- a/bench/algorithm/pidigits/4.py
+++ b/bench/algorithm/pidigits/4.py
@@ -5,7 +5,7 @@
 # Transliterated from GMP to built-in by Isaac Gouy
 
 from sys import argv
-
+from datetime import datetime
 
 def extract_Digit(nth):
     global tmp1, tmp2, acc, den, num
@@ -67,4 +67,7 @@ def main():
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
+
     main()

--- a/bench/algorithm/regex-redux/1.py
+++ b/bench/algorithm/regex-redux/1.py
@@ -10,6 +10,7 @@
 
 import sys
 from re import sub, findall
+from datetime import datetime
 
 
 seq = None
@@ -59,4 +60,6 @@ def main():
 
 
 if __name__ == "__main__":
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
     main()

--- a/bench/algorithm/secp256k1/1.py
+++ b/bench/algorithm/secp256k1/1.py
@@ -1,6 +1,7 @@
 # ported from 1.ts
 
 import sys
+from datetime import datetime
 
 P = 2 ** 256 - 2 ** 32 - 977
 N = 2 ** 256 - 432420386565659656852420866394968145599
@@ -173,4 +174,6 @@ def main():
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
     main()

--- a/bench/algorithm/spectral-norm/8.py
+++ b/bench/algorithm/spectral-norm/8.py
@@ -15,6 +15,7 @@ from itertools import repeat
 from math import sqrt
 from multiprocessing import Pool
 from sys import argv
+from datetime import datetime
 
 
 def eval_A(i, j):
@@ -62,5 +63,8 @@ def main():
 
 
 if __name__ == '__main__':
+    with open("ready", "w") as f:
+        f.write(str(round(datetime.utcnow().timestamp() * 1000)))
+
     with Pool(processes=4) as pool:
         main()

--- a/bench/tool/ProcessUtils.cs
+++ b/bench/tool/ProcessUtils.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using MathNet.Numerics.Statistics;
+using System.IO;
 using NLog;
 using static Interop;
 
@@ -37,6 +38,8 @@ namespace BenchTool
             {
                 Elapsed = TimeSpan.FromMilliseconds(array.Average(i => i.Elapsed.TotalMilliseconds)),
                 ElapsedStdDevMS = Statistics.StandardDeviation(array.Select(i => i.Elapsed.TotalMilliseconds)),
+                VMStart = TimeSpan.FromMilliseconds(array.Average(i => i.VMStart.TotalMilliseconds)),
+                VMStartStdDevMS = Statistics.StandardDeviation(array.Select(i => i.VMStart.TotalMilliseconds)),
                 CpuTimeKernel = avgCpuTimeKernel,
                 CpuTimeUser = avgCpuTimeUser,
                 PeakMemoryBytes = (long)Math.Round(maxPeakMemoryBytes),
@@ -50,6 +53,10 @@ namespace BenchTool
 
         public double ElapsedStdDevMS { get; set; }
 
+        public TimeSpan VMStart { get; set; }
+
+        public double VMStartStdDevMS { get; set; }
+
         public TimeSpan CpuTime => CpuTimeUser + CpuTimeKernel;
 
         public TimeSpan CpuTimeUser { get; set; }
@@ -60,7 +67,7 @@ namespace BenchTool
 
         public override string ToString()
         {
-            return $"[{Environment.ProcessorCount} cores]time: {Elapsed.TotalMilliseconds}ms, stddev: {ElapsedStdDevMS}ms, cpu-time: {CpuTime.TotalMilliseconds}ms, cpu-time-user: {CpuTimeUser.TotalMilliseconds}ms, cpu-time-kernel: {CpuTimeKernel.TotalMilliseconds}ms, peak-mem: {PeakMemoryBytes / 1024}KB";
+            return $"[{Environment.ProcessorCount} cores]time: {Elapsed.TotalMilliseconds}ms, stddev: {ElapsedStdDevMS}ms, vm-start: {VMStart.TotalMilliseconds}ms, vm-start-stddev: {VMStartStdDevMS}ms, cpu-time: {CpuTime.TotalMilliseconds}ms, cpu-time-user: {CpuTimeUser.TotalMilliseconds}ms, cpu-time-kernel: {CpuTimeKernel.TotalMilliseconds}ms, peak-mem: {PeakMemoryBytes / 1024}KB";
         }
     }
 
@@ -337,6 +344,15 @@ namespace BenchTool
                 }
             }, cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
+            string ready_file = Path.Combine(startInfo.WorkingDirectory, "ready");
+            // cleanup files from previous runs
+            if (File.Exists(ready_file))
+            {
+                File.Delete(ready_file);
+            }
+
+            DateTimeOffset process_start = DateTimeOffset.UtcNow;
+
             Stopwatch sw = Stopwatch.StartNew();
             int ret = await RunProcessAsync(
                 p,
@@ -350,6 +366,23 @@ namespace BenchTool
             sw.Stop();
             cts.Cancel();
             m.Elapsed = sw.Elapsed;
+            m.VMStart = TimeSpan.FromMilliseconds(0);
+            if (File.Exists(ready_file))
+            {
+                try
+                {
+                    String ready_file_content = await File.ReadAllTextAsync(ready_file).ConfigureAwait(false);
+                    long ready_utc = Convert.ToInt64(ready_file_content);
+                    m.VMStart = DateTimeOffset.FromUnixTimeMilliseconds(ready_utc) - process_start;
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e);
+                }
+
+                // ensure that next run will not use the same file
+                File.Delete(ready_file);
+            }
             await t.ConfigureAwait(false);
             return ret < 0 ? null : m;
         }

--- a/bench/tool/Program.cs
+++ b/bench/tool/Program.cs
@@ -754,6 +754,8 @@ namespace BenchTool
                         input = test.Input,
                         timeMS = statsMeasurement.Elapsed.TotalMilliseconds,
                         timeStdDevMS = statsMeasurement.ElapsedStdDevMS,
+                        vmStartMS = statsMeasurement.VMStart.TotalMilliseconds,
+                        vmStartStdDevMS = statsMeasurement.VMStartStdDevMS,
                         memBytes = statsMeasurement.PeakMemoryBytes,
                         cpuTimeMS = statsMeasurement.CpuTime.TotalMilliseconds,
                         cpuTimeUserMS = statsMeasurement.CpuTimeUser.TotalMilliseconds,

--- a/website/contentUtils.ts
+++ b/website/contentUtils.ts
@@ -27,6 +27,8 @@ export function mergeLangBenchResults(
     i.compilerVersion = getRealShortCompilerVersion(i)
     i.par = useParallelization(i)
     i.timeout = i.timeMS <= 0
+    i.vmStartMS = i.vmStartMS ?? null
+    i.vmStartStdDevMS = i.vmStartStdDevMS ?? null
   })
 
   const groupsByLang = _.chain(benchResults)

--- a/website/custom.d.ts
+++ b/website/custom.d.ts
@@ -16,6 +16,8 @@ type BenchResult = {
   code: string
   timeMS: number
   timeStdDevMS: number
+  vmStartMS: number | null
+  vmStartStdDevMS: number | null
   memBytes: number
   cpuTimeMS: number
   cpuTimeUserMS: number


### PR DESCRIPTION
This could solve #348 and #291.

Some languages running inside VM have quite large startup time. Measuring benchmark time from a process start to the end does include this VM startup phase. It could make sense for short-running processes like CLI instruments but for long running processes like web-servers it is usually does not matter.

Here I've added:
1. Step with measuring VM startup time. Process should create in a working directory a file named "ready", containing a Unix timestamp when a process is fully initialized and ready to run the main function.
2. `MeasureAsync` task checks this file content, extracts the timestamp, and calculates new metric `vmStartMS` as `ready timestamp - process start timestamp`. Just like `timeMS`, standart deviation is also measured. No file or empty file means that startup time is not recorded, and both values will be 0 (just like `timeMS`).
3. These new metrics are added to a table as columns `VM start time` and `VM start stddev`. They are shown only on pages containing measures with non-zero VM times, because there is no point to show VM start time for languages with no underlying VM. Also there is a checkbox which allows to hide new columns if user wants to.
4. There is another checkbox `substract VM startup time`, which substracts VM startup time from `total time` column. This allows to estimate real performance for long running tasks.

For example, Elixir VM startup time on Github runner machine is about 250ms while total process run time can be about 660-1300ms (depends on a benchmark), so VM startup time takes about 20-35% of the entire benchmark:
![image](https://user-images.githubusercontent.com/4661021/210657043-4a486aaa-d2fb-4c07-8a8b-91eecc9bee24.png)

Python VM takes less time to start, only 30-35ms, but for some tasks it could be about 10% of total time:
![image](https://user-images.githubusercontent.com/4661021/210658202-b06614b2-f75d-4bd3-8b66-3ceb6b8c7073.png)

In both cases, VM startup is much higher than standard deviation and cannot be discarded.

The proposed solution could be far from ideal, because it introduces additional IO operation during process start, but I don't see other ways this could be implemented. Printing the status into stdout/stderr is not working properly because `MeasureAsync` task uses shell and redirects both of these outputs to `/dev/null`.

Currently I've updated all `.py` files in the repo to generate this "ready" file. Other files should be updated separately. "hello-world" benchmark should be left intact because all it does is starting VM and then printing the output to the stdout.