### PR TITLE
crystal: optimize the build command even further

### DIFF
--- a/bench/bench_crystal.yaml
+++ b/bench/bench_crystal.yaml
@@ -66,6 +66,6 @@ environments:
     include_sub_dir: src
     before_build:
       - shards install
-    build: shards build --release --mcpu=broadwell --verbose
+    build: shards build --release --no-debug --mcpu=native --verbose
     out_dir: bin
     run_cmd: app


### PR DESCRIPTION
It's suggested that you build with: `--release --no-debug` in order to optimize for performance. 

Also, the documentation states the following about `--mcpu=`:

```
               --mcpu CPU
                         Specify a specific CPU to generate code for. This will pass a -mcpu flag to LLVM, and is only intended to be used for cross-compilation. For
                         a list of available CPUs, invoke "llvm-as < /dev/null | llc -march=xyz -mcpu=help".  Passing --mcpu native will pass the host CPU name to
                         tune performance for the host.
```

If we are to use it, then, at the very least, use `--mcpu=native`.