### PR TITLE
Tell Acton to target native platform

### DIFF
--- a/bench/bench_acton.yaml
+++ b/bench/bench_acton.yaml
@@ -15,7 +15,7 @@ environments:
     compiler: actonc
     compiler_version_command: actonc --version
     version: latest
-    build: actonc app.act
+    build: actonc --target native app.act
     after_build:
       - mv app out
     out_dir: out


### PR DESCRIPTION
By default, Acton optimizes for portability, so on Linux, the output binary targets GNU libc 2.27, which is rather old (~Ubuntu 18.04). It also only uses base features of the x86_64 CPU, so features like AVX512 or similar would not be used. By setting --target native, the output executable is instead optimized for the machine we are running on and can typically run much faster, sometimes up to 2x faster.