### PR TITLE
Add `-skip-unused` flag to V build commands

### DIFF
--- a/bench/bench_v.yaml
+++ b/bench/bench_v.yaml
@@ -57,7 +57,7 @@ environments:
     compiler: v/clang+gc
     version: latest
     include:
-    build: v -prod -gc boehm_full_opt -cc clang -cflags "-march=broadwell" -stats -showcc -no-rsp app.v
+    build: v -prod -gc boehm_full_opt -skip-unused -cc clang -cflags "-march=broadwell" -stats -showcc -no-rsp app.v
     after_build:
       - mv app out
     out_dir: out

--- a/bench/bench_v_autofree.yaml
+++ b/bench/bench_v_autofree.yaml
@@ -57,7 +57,7 @@ environments:
     compiler: v/clang
     version: latest
     include:
-    build: v -prod -autofree -cc clang -cflags "-march=broadwell" -stats -showcc -no-rsp app.v
+    build: v -prod -autofree -skip-unused -cc clang -cflags "-march=broadwell" -stats -showcc -no-rsp app.v
     after_build:
       - mv app out
     out_dir: out


### PR DESCRIPTION
This PR adds `-skip-unused` build option to V benchmarks build commands. V has a few consts and init functions, that are run even for empty .v file, causing unneeded allocations and operations.

With `-skip-unused`, unused code is stripped before compilation, so unneeded allocations and init things are not invoked, which can lead to better performance in microbenchmarks like helloworld.

Since `-skip-unused` will be default somewhere in the future (right now it doesn't work with some V UI programs), I think this is not cheating to use it in these benchmarks.