### PR TITLE
Use http instead of https in C# http-server

### DIFF
--- a/bench/algorithm/http-server/2-http2.cs
+++ b/bench/algorithm/http-server/2-http2.cs
@@ -54,7 +54,7 @@ static class Program
 
         using var serverTask = app.RunAsync();
         var sum = 0;
-        var api = $"https://localhost:{port}/";
+        var api = $"http://localhost:{port}/";
         var tasks = new List<Task<int>>(n);
         for (var i = 1; i <= n; i++)
         {
@@ -100,7 +100,6 @@ static class Program
             options.ListenLocalhost(port, listenOptions =>
             {
                 listenOptions.Protocols = HttpProtocols.Http2;
-                listenOptions.UseHttps();
             });
         });
         return builder.Build();

--- a/bench/algorithm/http-server/2-http3.cs
+++ b/bench/algorithm/http-server/2-http3.cs
@@ -54,7 +54,7 @@ static class Program
 
         using var serverTask = app.RunAsync();
         var sum = 0;
-        var api = $"https://localhost:{port}/";
+        var api = $"http://localhost:{port}/";
         var tasks = new List<Task<int>>(n);
         for (var i = 1; i <= n; i++)
         {
@@ -100,7 +100,6 @@ static class Program
             options.ListenLocalhost(port, listenOptions =>
             {
                 listenOptions.Protocols = HttpProtocols.Http3;
-                listenOptions.UseHttps();
             });
         });
         return builder.Build();


### PR DESCRIPTION
It seems other languages http-server uses http instead of https, so let's make it http also in C# http-server