### PR TITLE
add rust version of sonic to serde-json

### DIFF
--- a/bench/algorithm/json-serde/5-i.rs
+++ b/bench/algorithm/json-serde/5-i.rs
@@ -1,0 +1,70 @@
+use serde::{Deserialize, Serialize, Serializer};
+use std::fs;
+
+fn main() -> anyhow::Result<()> {
+    let file_name = std::env::args_os()
+        .nth(1)
+        .and_then(|s| s.into_string().ok())
+        .unwrap_or("sample".to_string());
+    let n = std::env::args_os()
+        .nth(2)
+        .and_then(|s| s.into_string().ok())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
+    let mut json_str = fs::read(format!("{}.json", file_name))?;
+    let json: GeoData = sonic_rs::from_slice(&mut json_str)?;
+
+    print_hash(sonic_rs::to_vec(&json)?);
+    let mut array = Vec::with_capacity(n);
+    for _i in 0..n {
+        let json: GeoData = sonic_rs::from_slice(&mut json_str)?;
+        array.push(json);
+    }
+    print_hash(sonic_rs::to_vec(&array)?);
+    Ok(())
+}
+
+fn print_hash(bytes: impl AsRef<[u8]>) {
+    let digest = md5::compute(&bytes);
+    println!("{:x}", digest);
+}
+
+#[derive(Deserialize, Debug, Default)]
+struct MyF64(f64);
+
+impl Serialize for MyF64 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.0.fract() == 0.0 {
+            serializer.serialize_i64(self.0 as i64)
+        } else {
+            serializer.serialize_f64(self.0)
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Default)]
+struct GeoData {
+    r#type: String,
+    features: Vec<Feature>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Default)]
+struct Feature {
+    r#type: String,
+    properties: Properties,
+    geometry: Geometry,
+}
+
+#[derive(Deserialize, Serialize, Debug, Default)]
+struct Properties {
+    name: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Default)]
+struct Geometry {
+    r#type: String,
+    coordinates: Vec<Vec<[MyF64; 2]>>,
+}

--- a/bench/bench_rust.yaml
+++ b/bench/bench_rust.yaml
@@ -60,6 +60,7 @@ problems:
       - 2.rs
       - 3.rs
       - 4-i.rs
+      - 5-i.rs
   - name: coro-prime-sieve
     source:
       - 1.rs

--- a/bench/include/rust/Cargo.toml
+++ b/bench/include/rust/Cargo.toml
@@ -43,6 +43,7 @@ regex = "1"
 serde = {version = "1", features = ["derive"]}
 serde_json = {version = "1", features = ["float_roundtrip", "preserve_order"]}
 simd-json = "0.13"
+sonic-rs = "0.3"
 static-rc = "0"
 
 async-channel = {version = "2", optional = true}


### PR DESCRIPTION
There are 3 versions of sonic library, all of them are implemented by the same company, the go version is used in the `2-ffi.go`, the [rust version](https://github.com/cloudwego/sonic-rs) is in this pr, and the last is [c++ version](https://github.com/bytedance/sonic-cpp). So, if you are interested, you may contribute to a cpp version with it, since I am not quite sure about the code template for c++ version.