### PR TITLE
Improve Nim coro-prime-sieve implementation so that it does not timeout

### DIFF
--- a/bench/algorithm/coro-prime-sieve/3.nim
+++ b/bench/algorithm/coro-prime-sieve/3.nim
@@ -1,0 +1,37 @@
+## Coro-prime-sieve
+## Author: Navid M
+
+import std/[
+  os,
+  strutils
+]
+
+proc generate(limit: int): seq[int] =
+  ## Generate a sequence of numbers starting from 2
+  result = newSeq[int]()
+  var i = 2
+  while i <= limit:
+    result.add(i)
+    inc i
+
+proc filter(numbers: seq[int], prime: int): seq[int] =
+  ## Filter the numbers by removing multiples of the given prime
+  result = newSeq[int]()
+  for i in numbers:
+    if i == prime or i mod prime != 0:
+      result.add(i)
+
+when isMainModule:
+  let n = if paramCount() < 1: 100 else: parseInt(paramStr(1))
+  var
+    numbers = generate(int(high(int16)) * 3)
+    primesFound = 0
+    i = 0
+  while primesFound < n:
+    if i == numbers.len - 1:
+      break
+    let prime = numbers[i]
+    echo prime
+    inc primesFound
+    numbers = filter(numbers, prime)
+    inc i

--- a/bench/bench_nim.yaml
+++ b/bench/bench_nim.yaml
@@ -31,6 +31,7 @@ problems:
       - 1.nim
   - name: coro-prime-sieve
     source:
+      - 3.nim
       - 1.nim
   - name: lru
     source:


### PR DESCRIPTION
The current implementations timeout for the input value 4000. This one does not.