### PR TITLE
zigcc unknown mandebrot: fixing zig cc flags and version command in .yaml

### DIFF
--- a/bench/bench_c_ffi.yaml
+++ b/bench/bench_c_ffi.yaml
@@ -35,9 +35,10 @@ environments:
   - os: linux
     compiler: zigcc
     version: latest
+    compiler_version_command: zig version
     docker:
     include: c
-    build: zig cc  -pipe -O3 -fomit-frame-pointer -march=native -Wno-deprecated-declarations -mno-fma -o app app.c -lm -lcrypto
+    build: zig cc  -pipe -O3 -fomit-frame-pointer -march=broadwell -Wno-deprecated-declarations -mno-fma -o app app.c -lm -lcrypto
     after_build:
       - mv app out
     out_dir: out


### PR DESCRIPTION
Sorry about your wasted time I should noticed this beforehead.

fixing -march=native to broadwell (which is used every where in this repo)
fixing the version command for zig cc