### PR TITLE
Use Convert.ToHexStringLower() in C#

### DIFF
--- a/bench/algorithm/json-serde/1.cs
+++ b/bench/algorithm/json-serde/1.cs
@@ -32,14 +32,6 @@ static class Program
     {
         using var hasher = MD5.Create();
         var hash = hasher.ComputeHash(Encoding.UTF8.GetBytes(s));
-        Console.WriteLine(ToHexString(hash));
-    }
-
-    static string ToHexString(byte[] ba)
-    {
-        StringBuilder hex = new StringBuilder(ba.Length * 2);
-        foreach (byte b in ba)
-            hex.AppendFormat("{0:x2}", b);
-        return hex.ToString();
+        Console.WriteLine(Convert.ToHexStringLower(hash));
     }
 }

--- a/bench/algorithm/json-serde/2.cs
+++ b/bench/algorithm/json-serde/2.cs
@@ -30,7 +30,7 @@ internal static class Program
     {
         using MD5 hasher = MD5.Create();
         byte[] hash = hasher.ComputeHash(bytes);
-        Console.WriteLine(Convert.ToHexString(hash).ToLower());
+        Console.WriteLine(Convert.ToHexStringLower(hash));
     }
 }
 internal sealed class GeoData

--- a/bench/algorithm/mandelbrot/1.cs
+++ b/bench/algorithm/mandelbrot/1.cs
@@ -42,7 +42,7 @@ public class MandelBrot
 
         using var hasher = MD5.Create();
         var hash = hasher.ComputeHash(data);
-        Console.WriteLine(ToHexString(hash));
+        Console.WriteLine(Convert.ToHexStringLower(hash));
     }
 
     static byte mbrot8(double[] cr, double civ)
@@ -117,15 +117,5 @@ public class MandelBrot
         {
             r[i] = a[i] * b[i];
         }
-    }
-
-    static string ToHexString(byte[] ba)
-    {
-        StringBuilder hex = new StringBuilder(ba.Length * 2);
-        foreach (byte b in ba)
-        {
-            hex.AppendFormat("{0:x2}", b);
-        }
-        return hex.ToString();
     }
 }

--- a/bench/algorithm/mandelbrot/2.cs
+++ b/bench/algorithm/mandelbrot/2.cs
@@ -44,7 +44,7 @@ public class MandelBrot
 
         using var hasher = MD5.Create();
         var hash = hasher.ComputeHash(data);
-        Console.WriteLine(ToHexString(hash));
+        Console.WriteLine(Convert.ToHexStringLower(hash));
     }
 
     static byte mbrot8((Vector<double>, Vector<double>) cr, double civ)
@@ -102,15 +102,5 @@ public class MandelBrot
             }
         }
         return accu;
-    }
-
-    static string ToHexString(byte[] ba)
-    {
-        StringBuilder hex = new StringBuilder(ba.Length * 2);
-        foreach (byte b in ba)
-        {
-            hex.AppendFormat("{0:x2}", b);
-        }
-        return hex.ToString();
     }
 }

--- a/bench/algorithm/mandelbrot/3.cs
+++ b/bench/algorithm/mandelbrot/3.cs
@@ -92,7 +92,7 @@ public class MandelBrot
 
         using var hasher = MD5.Create();
         var hash = hasher.ComputeHash(data);
-        Console.WriteLine(ToHexString(hash));
+        Console.WriteLine(Convert.ToHexStringLower(hash));
     }
 
     unsafe static byte mbrot8(F64x8 cr, double civ)
@@ -143,15 +143,5 @@ public class MandelBrot
             }
         }
         return accu;
-    }
-
-    static string ToHexString(byte[] ba)
-    {
-        StringBuilder hex = new StringBuilder(ba.Length * 2);
-        foreach (byte b in ba)
-        {
-            hex.AppendFormat("{0:x2}", b);
-        }
-        return hex.ToString();
     }
 }

--- a/bench/algorithm/mandelbrot/9-m.cs
+++ b/bench/algorithm/mandelbrot/9-m.cs
@@ -83,17 +83,7 @@ public class MandelBrot
             });
             using var hasher = MD5.Create();
             var hash = hasher.ComputeHash(data);
-            Console.WriteLine(ToHexString(hash));
+            Console.WriteLine(Convert.ToHexStringLower(hash));
         }
-    }
-
-    static string ToHexString(byte[] ba)
-    {
-        StringBuilder hex = new StringBuilder(ba.Length * 2);
-        foreach (byte b in ba)
-        {
-            hex.AppendFormat("{0:x2}", b);
-        }
-        return hex.ToString();
     }
 }

--- a/bench/algorithm/mandelbrot/9.cs
+++ b/bench/algorithm/mandelbrot/9.cs
@@ -83,17 +83,7 @@ public class MandelBrot
             }
             using var hasher = MD5.Create();
             var hash = hasher.ComputeHash(data);
-            Console.WriteLine(ToHexString(hash));
+            Console.WriteLine(Convert.ToHexStringLower(hash));
         }
-    }
-
-    static string ToHexString(byte[] ba)
-    {
-        StringBuilder hex = new StringBuilder(ba.Length * 2);
-        foreach (byte b in ba)
-        {
-            hex.AppendFormat("{0:x2}", b);
-        }
-        return hex.ToString();
     }
 }


### PR DESCRIPTION
There's a bunch of custom-made `ToHexString()` methods with the same implementation. As per [Performance Improvements in .NET 9](https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-9/#encoding), it's better to use built-in and optimized [`Convert.ToHexStringLower()`](https://learn.microsoft.com/en-us/dotnet/api/system.convert.tohexstringlower?view=net-9.0) method.
That way, it will both (a) reduce code duplication and (b) slightly improve performance.