### PR TITLE
Bump Kotlin Version to 2.1.10

### DIFF
--- a/bench/include/kotlin-jvm/build.gradle.kts
+++ b/bench/include/kotlin-jvm/build.gradle.kts
@@ -21,11 +21,6 @@ repositories {
     gradlePluginPortal()
 }
 
-application {
-    // Define the main class for the application.
-    mainClassName = "MainKt"
-}
-
 dependencies {
     // implementation(kotlin("stdlib"))
     // implementation("org.slf4j:slf4j-api:1.7.36")

--- a/bench/include/kotlin-jvm/gradle/wrapper/gradle-wrapper.properties
+++ b/bench/include/kotlin-jvm/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/bench/include/kotlin-jvm/settings.gradle.kts
+++ b/bench/include/kotlin-jvm/settings.gradle.kts
@@ -1,3 +1,1 @@
 rootProject.name = "app"
-// https://docs.gradle.org/7.0/release-notes.html
-enableFeaturePreview("VERSION_CATALOGS")

--- a/bench/include/kotlin-native/build.gradle.kts
+++ b/bench/include/kotlin-native/build.gradle.kts
@@ -3,10 +3,10 @@ import org.jetbrains.kotlin.config.KotlinCompilerVersion
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
-  val kotlinVersion = "1.8.21"
+  val kotlinVersion = "2.1.10"
   kotlin("multiplatform").version(kotlinVersion)
   kotlin("plugin.serialization").version(kotlinVersion)
-  id("com.github.ben-manes.versions").version("0.46.0")
+  id("com.github.ben-manes.versions").version("0.52.0")
 }
 
 repositories {
@@ -24,8 +24,8 @@ kotlin {
         implementation(libs.bignum)
         implementation(libs.kbignum)
         // implementation("com.ionspin.kotlin:bignum:0.3.1")
-        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
-        implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
+        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+        implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.0")
       }
     }
   }
@@ -41,8 +41,7 @@ kotlin {
 //
 kotlin.targets.withType(KotlinNativeTarget::class.java) {
   binaries.all {
-    binaryOptions["memoryModel"] = "experimental"
-    // freeCompilerArgs += "-Xruntime-logs=gc=info"
+     freeCompilerArgs += "opt"
   }
 }
 

--- a/bench/include/kotlin-native/gradle.properties
+++ b/bench/include/kotlin-native/gradle.properties
@@ -1,3 +1,2 @@
 https.protocols=TLSv1.2,TLSv1.3
 kotlin.mpp.stability.nowarn=true
-kotlin.native.binary.memoryModel=experimental

--- a/bench/include/kotlin-native/gradle/libs.versions.toml
+++ b/bench/include/kotlin-native/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 [libraries]
-bignum = {module = "com.ionspin.kotlin:bignum", version = "0.3.8"}
-kbignum = {module = "com.soywiz.korlibs.kbignum:kbignum", version = "3.4.0"}
+bignum = {module = "com.ionspin.kotlin:bignum", version = "0.3.10"}
+kbignum = {module = "com.soywiz.korlibs.kbignum:kbignum", version = "4.0.10"}
 
 [bundles]

--- a/bench/include/kotlin-native/gradle/wrapper/gradle-wrapper.properties
+++ b/bench/include/kotlin-native/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/bench/include/kotlin-native/settings.gradle.kts
+++ b/bench/include/kotlin-native/settings.gradle.kts
@@ -1,2 +1,1 @@
-// https://docs.gradle.org/7.0/release-notes.html
-enableFeaturePreview("VERSION_CATALOGS")
+


### PR DESCRIPTION
Bump Kotlin and Gradle to newer versions

- Kotlin version 2.1.10 has some performance improvement since the previous implemented (1.8.21), so I'm eager to see how it's compares with other languages now.

- Removing warnings related to deprecated experimental memory model. Seems that they got that merged into newer versions already.

- Removed Versions Catalog feature preview flag. It's already a stable and we don't need that anymore.

- Gradlew (and bat) files got updated with newer Gradle version.