### PR TITLE
Replace Newtonsoft.Json on native System.Text.Json in the "json-serde/1.cs" benchmark

### DIFF
--- a/bench/algorithm/json-serde/1.cs
+++ b/bench/algorithm/json-serde/1.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 static class Program
 {
@@ -18,14 +19,16 @@ static class Program
         }
 
         var jsonStr = await File.ReadAllTextAsync($"{fileName}.json").ConfigureAwait(false);
-        var data = JsonConvert.DeserializeObject(jsonStr);
-        PrintHash(JsonConvert.SerializeObject(data));
+        var jti = JsonTypeInfo.CreateJsonTypeInfo<Object>(JsonSerializerOptions.Default);
+        var data = JsonSerializer.Deserialize(jsonStr, jti);
+        
+        PrintHash(JsonSerializer.Serialize(data));
         var list = new List<object>(n);
         for (var i = 0; i < n; i++)
         {
-            list.Add(JsonConvert.DeserializeObject(jsonStr));
+            list.Add(JsonSerializer.Deserialize(jsonStr, jti));
         }
-        PrintHash(JsonConvert.SerializeObject(list));
+        PrintHash(JsonSerializer.Serialize(list));
     }
 
     private static void PrintHash(string s)


### PR DESCRIPTION
Related with https://github.com/hanabi1224/Programming-Language-Benchmarks/issues/457

Using NET9 changes that increase deserialization and serialization performance.
_I won't duplicate the information from the issue, I hope you'll forgive me for that :D_